### PR TITLE
Remove sphere rendering for editor points in 3D viewer

### DIFF
--- a/pulse/interface/viewer_3d/actors/editor_points_actor.py
+++ b/pulse/interface/viewer_3d/actors/editor_points_actor.py
@@ -21,7 +21,6 @@ class EditorPointsActor(GhostActor):
         self.SetMapper(mapper)
 
         self.GetProperty().SetPointSize(15)
-        self.GetProperty().RenderPointsAsSpheresOn()
         editor_points_color = self.user_preferences.nodes_points_color.to_rgb()
         self.GetProperty().SetColor([i / 255 for i in editor_points_color])
         self.GetProperty().LightingOff()

--- a/pulse/interface/viewer_3d/actors/editor_selected_points_actor.py
+++ b/pulse/interface/viewer_3d/actors/editor_selected_points_actor.py
@@ -20,7 +20,6 @@ class EditorSelectedPointsActor(GhostActor):
         self.SetMapper(mapper)
 
         self.GetProperty().SetPointSize(15)
-        self.GetProperty().RenderPointsAsSpheresOn()
         self.GetProperty().SetColor([i / 255 for i in (255, 50, 50)])
         self.GetProperty().LightingOff()
         self.make_ghost()


### PR DESCRIPTION
On my personal laptop, points are not visible in the editor unless this setting is disabled.  
Since staged points are not configured with this setting, I believe this minor change to the points actor can be applied without significant concerns.