### PR TITLE
Compatibility mode for points visualization

### DIFF
--- a/pulse/interface/data/ui_files/project/render/renderer_user_preferences.ui
+++ b/pulse/interface/data/ui_files/project/render/renderer_user_preferences.ui
@@ -7,19 +7,19 @@
     <x>0</x>
     <y>0</y>
     <width>480</width>
-    <height>480</height>
+    <height>520</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>480</width>
-    <height>480</height>
+    <height>520</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
     <width>480</width>
-    <height>480</height>
+    <height>520</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -155,12 +155,12 @@
       <property name="spacing">
        <number>4</number>
       </property>
-      <item row="0" column="0">
+      <item row="0" column="0" alignment="Qt::AlignTop">
        <widget class="QFrame" name="frame_6">
         <property name="minimumSize">
          <size>
           <width>240</width>
-          <height>80</height>
+          <height>120</height>
          </size>
         </property>
         <property name="maximumSize">
@@ -191,6 +191,37 @@
          <property name="spacing">
           <number>4</number>
          </property>
+         <item row="0" column="1">
+          <widget class="QCheckBox" name="checkBox_OpenPulse_logo">
+           <property name="minimumSize">
+            <size>
+             <width>160</width>
+             <height>26</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>180</width>
+             <height>26</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <family>MS Shell Dlg 2</family>
+             <pointsize>10</pointsize>
+             <weight>50</weight>
+             <italic>false</italic>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Show OpenPulse logo</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
          <item row="0" column="2">
           <spacer name="horizontalSpacer_2">
            <property name="orientation">
@@ -248,8 +279,11 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="1">
-          <widget class="QCheckBox" name="checkBox_OpenPulse_logo">
+         <item row="2" column="1">
+          <widget class="QCheckBox" name="checkBox_compatibility_mode">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
            <property name="minimumSize">
             <size>
              <width>160</width>
@@ -271,11 +305,14 @@
              <bold>false</bold>
             </font>
            </property>
+           <property name="toolTip">
+            <string>If the points are not being shown in your renderers, try this option.</string>
+           </property>
            <property name="text">
-            <string>Show OpenPulse logo</string>
+            <string>Compatibility mode</string>
            </property>
            <property name="checked">
-            <bool>true</bool>
+            <bool>false</bool>
            </property>
           </widget>
          </item>
@@ -287,7 +324,7 @@
         <property name="minimumSize">
          <size>
           <width>320</width>
-          <height>42</height>
+          <height>280</height>
          </size>
         </property>
         <property name="maximumSize">
@@ -321,100 +358,8 @@
          <property name="verticalSpacing">
           <number>4</number>
          </property>
-         <item row="8" column="3">
-          <widget class="QLabel" name="label_3">
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="text">
-            <string>pt</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="2">
-          <widget class="QLineEdit" name="lineEdit_renderer_font_size">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>90</width>
-             <height>26</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>90</width>
-             <height>26</height>
-            </size>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="3">
-          <widget class="QPushButton" name="pushButton_renderer_background_color_2">
-           <property name="minimumSize">
-            <size>
-             <width>90</width>
-             <height>26</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>90</width>
-             <height>26</height>
-            </size>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="text">
-            <string>Pick color</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="4">
-          <spacer name="horizontalSpacer_5">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="1" column="0">
-          <spacer name="horizontalSpacer_3">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="2" column="2">
-          <widget class="QLineEdit" name="lineEdit_renderer_background_color_2">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
+         <item row="7" column="3">
+          <widget class="QPushButton" name="pushButton_tubes_color">
            <property name="minimumSize">
             <size>
              <width>90</width>
@@ -430,8 +375,69 @@
            <property name="font">
             <font>
              <family>Arial</family>
-             <pointsize>11</pointsize>
+             <pointsize>8</pointsize>
             </font>
+           </property>
+           <property name="styleSheet">
+            <string notr="true"/>
+           </property>
+           <property name="text">
+            <string>Pick color</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="3">
+          <widget class="QLabel" name="label_3">
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="text">
+            <string>pt</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="6" column="3">
+          <widget class="QPushButton" name="pushButton_lines_color">
+           <property name="minimumSize">
+            <size>
+             <width>90</width>
+             <height>26</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>90</width>
+             <height>26</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="styleSheet">
+            <string notr="true"/>
+           </property>
+           <property name="text">
+            <string>Pick color</string>
            </property>
           </widget>
          </item>
@@ -469,8 +475,24 @@
            </property>
           </widget>
          </item>
-         <item row="6" column="3">
-          <widget class="QPushButton" name="pushButton_lines_color">
+         <item row="1" column="4">
+          <spacer name="horizontalSpacer_5">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="8" column="2">
+          <widget class="QLineEdit" name="lineEdit_renderer_font_size">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
            <property name="minimumSize">
             <size>
              <width>90</width>
@@ -488,11 +510,38 @@
              <pointsize>8</pointsize>
             </font>
            </property>
-           <property name="styleSheet">
-            <string notr="true"/>
+          </widget>
+         </item>
+         <item row="8" column="1">
+          <widget class="QLabel" name="label_2">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>160</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>160</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>160</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
            </property>
            <property name="text">
-            <string>Pick color</string>
+            <string>Renderer font size</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
           </widget>
          </item>
@@ -526,44 +575,17 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="3">
-          <widget class="QPushButton" name="pushButton_renderer_background_color_1">
+         <item row="1" column="1">
+          <widget class="QLabel" name="label_10">
            <property name="minimumSize">
             <size>
-             <width>90</width>
-             <height>26</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>90</width>
-             <height>26</height>
-            </size>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="styleSheet">
-            <string notr="true"/>
-           </property>
-           <property name="text">
-            <string>Pick color</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="1">
-          <widget class="QLabel" name="label_12">
-           <property name="minimumSize">
-            <size>
-             <width>160</width>
+             <width>170</width>
              <height>32</height>
             </size>
            </property>
            <property name="maximumSize">
             <size>
-             <width>160</width>
+             <width>170</width>
              <height>32</height>
             </size>
            </property>
@@ -579,104 +601,10 @@
             <enum>QFrame::Raised</enum>
            </property>
            <property name="text">
-            <string>Renderer font color:</string>
+            <string>Renderer background color 1:</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="1">
-          <widget class="QLabel" name="label_8">
-           <property name="minimumSize">
-            <size>
-             <width>160</width>
-             <height>32</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>160</width>
-             <height>32</height>
-            </size>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="frameShape">
-            <enum>QFrame::NoFrame</enum>
-           </property>
-           <property name="frameShadow">
-            <enum>QFrame::Raised</enum>
-           </property>
-           <property name="text">
-            <string>Tubes color:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="3">
-          <widget class="QPushButton" name="pushButton_renderer_font_color">
-           <property name="minimumSize">
-            <size>
-             <width>90</width>
-             <height>26</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>90</width>
-             <height>26</height>
-            </size>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="styleSheet">
-            <string notr="true"/>
-           </property>
-           <property name="text">
-            <string>Pick color</string>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="2">
-          <widget class="QLineEdit" name="lineEdit_lines_color">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>90</width>
-             <height>26</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>90</width>
-             <height>26</height>
-            </size>
-           </property>
-           <property name="font">
-            <font>
-             <family>Arial</family>
-             <pointsize>11</pointsize>
-             <weight>75</weight>
-             <italic>false</italic>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="styleSheet">
-            <string notr="true"/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
            </property>
           </widget>
          </item>
@@ -714,18 +642,18 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="1">
-          <widget class="QLabel" name="label_10">
+         <item row="4" column="3">
+          <widget class="QPushButton" name="pushButton_renderer_font_color">
            <property name="minimumSize">
             <size>
-             <width>170</width>
-             <height>32</height>
+             <width>90</width>
+             <height>26</height>
             </size>
            </property>
            <property name="maximumSize">
             <size>
-             <width>170</width>
-             <height>32</height>
+             <width>90</width>
+             <height>26</height>
             </size>
            </property>
            <property name="font">
@@ -733,17 +661,35 @@
              <pointsize>8</pointsize>
             </font>
            </property>
-           <property name="frameShape">
-            <enum>QFrame::NoFrame</enum>
-           </property>
-           <property name="frameShadow">
-            <enum>QFrame::Raised</enum>
+           <property name="styleSheet">
+            <string notr="true"/>
            </property>
            <property name="text">
-            <string>Renderer background color 1:</string>
+            <string>Pick color</string>
            </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </widget>
+         </item>
+         <item row="2" column="3">
+          <widget class="QPushButton" name="pushButton_renderer_background_color_2">
+           <property name="minimumSize">
+            <size>
+             <width>90</width>
+             <height>26</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>90</width>
+             <height>26</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="text">
+            <string>Pick color</string>
            </property>
           </widget>
          </item>
@@ -781,66 +727,6 @@
            </property>
           </widget>
          </item>
-         <item row="6" column="1">
-          <widget class="QLabel" name="label_7">
-           <property name="minimumSize">
-            <size>
-             <width>160</width>
-             <height>32</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>160</width>
-             <height>32</height>
-            </size>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="frameShape">
-            <enum>QFrame::NoFrame</enum>
-           </property>
-           <property name="frameShadow">
-            <enum>QFrame::Raised</enum>
-           </property>
-           <property name="text">
-            <string>Lines color:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="3">
-          <widget class="QPushButton" name="pushButton_nodes_points_color">
-           <property name="minimumSize">
-            <size>
-             <width>90</width>
-             <height>26</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>90</width>
-             <height>26</height>
-            </size>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="styleSheet">
-            <string notr="true"/>
-           </property>
-           <property name="text">
-            <string>Pick color</string>
-           </property>
-          </widget>
-         </item>
          <item row="7" column="2">
           <widget class="QLineEdit" name="lineEdit_tubes_color">
            <property name="enabled">
@@ -875,6 +761,218 @@
            </property>
           </widget>
          </item>
+         <item row="2" column="2">
+          <widget class="QLineEdit" name="lineEdit_renderer_background_color_2">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>90</width>
+             <height>26</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>90</width>
+             <height>26</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <family>Arial</family>
+             <pointsize>11</pointsize>
+            </font>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="2">
+          <widget class="QLineEdit" name="lineEdit_lines_color">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>90</width>
+             <height>26</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>90</width>
+             <height>26</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <family>Arial</family>
+             <pointsize>11</pointsize>
+             <weight>75</weight>
+             <italic>false</italic>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="styleSheet">
+            <string notr="true"/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="3">
+          <widget class="QPushButton" name="pushButton_renderer_background_color_1">
+           <property name="minimumSize">
+            <size>
+             <width>90</width>
+             <height>26</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>90</width>
+             <height>26</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="styleSheet">
+            <string notr="true"/>
+           </property>
+           <property name="text">
+            <string>Pick color</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="1">
+          <widget class="QLabel" name="label_8">
+           <property name="minimumSize">
+            <size>
+             <width>160</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>160</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="frameShape">
+            <enum>QFrame::NoFrame</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Raised</enum>
+           </property>
+           <property name="text">
+            <string>Tubes color:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="3">
+          <widget class="QPushButton" name="pushButton_nodes_points_color">
+           <property name="minimumSize">
+            <size>
+             <width>90</width>
+             <height>26</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>90</width>
+             <height>26</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="styleSheet">
+            <string notr="true"/>
+           </property>
+           <property name="text">
+            <string>Pick color</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="QLabel" name="label_7">
+           <property name="minimumSize">
+            <size>
+             <width>160</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>160</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="frameShape">
+            <enum>QFrame::NoFrame</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Raised</enum>
+           </property>
+           <property name="text">
+            <string>Lines color:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="QLabel" name="label_12">
+           <property name="minimumSize">
+            <size>
+             <width>160</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>160</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="frameShape">
+            <enum>QFrame::NoFrame</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Raised</enum>
+           </property>
+           <property name="text">
+            <string>Renderer font color:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
          <item row="5" column="1">
           <widget class="QLabel" name="label_6">
            <property name="minimumSize">
@@ -902,67 +1000,6 @@
            </property>
            <property name="text">
             <string>Nodes/Points color:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="3">
-          <widget class="QPushButton" name="pushButton_tubes_color">
-           <property name="minimumSize">
-            <size>
-             <width>90</width>
-             <height>26</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>90</width>
-             <height>26</height>
-            </size>
-           </property>
-           <property name="font">
-            <font>
-             <family>Arial</family>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="styleSheet">
-            <string notr="true"/>
-           </property>
-           <property name="text">
-            <string>Pick color</string>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="1">
-          <widget class="QLabel" name="label_2">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>160</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>160</width>
-             <height>32</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>160</width>
-             <height>32</height>
-            </size>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="text">
-            <string>Renderer font size</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/pulse/interface/user_input/project/renderer_user_preferences.py
+++ b/pulse/interface/user_input/project/renderer_user_preferences.py
@@ -44,6 +44,7 @@ class RendererUserPreferencesInput(QDialog):
         # QCheckBox
         self.checkBox_OpenPulse_logo : QCheckBox
         self.checkBox_reference_scale : QCheckBox
+        self.checkBox_compatibility_mode : QCheckBox
 
         # QFrame
         self.frame_background_color : QFrame
@@ -205,6 +206,7 @@ class RendererUserPreferencesInput(QDialog):
         self.update_open_pulse_logo_state()
         self.update_reference_scale_state()
         self.update_renderers_font_size()
+        self.update_compatibility_mode_state()
         self.main_window.update_plots()
 
     def reset_to_default(self):
@@ -251,10 +253,7 @@ class RendererUserPreferencesInput(QDialog):
             self.main_window.mesh_widget.disable_open_pulse_logo()
 
     def update_show_open_pulse_logo_checkbox(self):
-        if self.user_preferences.show_open_pulse_logo:
-            self.checkBox_OpenPulse_logo.setChecked(1)
-        else:
-            self.checkBox_OpenPulse_logo.setChecked(0)
+        self.checkBox_OpenPulse_logo.setChecked(self.user_preferences.show_open_pulse_logo)
 
     def update_reference_scale_state(self):
         if self.checkBox_reference_scale.isChecked():
@@ -267,11 +266,14 @@ class RendererUserPreferencesInput(QDialog):
             self.main_window.mesh_widget.disable_scale_bar()
 
     def update_show_reference_scalebar_checkbox(self):
-        if self.user_preferences.show_reference_scale_bar:
-            self.checkBox_reference_scale.setChecked(1)
-        else:
-            self.checkBox_reference_scale.setChecked(0)
+        self.checkBox_reference_scale.setChecked(self.user_preferences.show_reference_scale_bar)
         
+    def update_compatibility_mode_state(self):
+        self.user_preferences.compatibility_mode = self.checkBox_compatibility_mode.isChecked()
+
+    def update_compatibility_mode_checkbox(self):
+        self.checkBox_compatibility_mode.setChecked(self.user_preferences.compatibility_mode)
+
     def update_renderers_font_size(self):
         self.main_window.geometry_widget.update_renderer_font_size()
         self.main_window.results_widget.update_renderer_font_size()
@@ -287,6 +289,7 @@ class RendererUserPreferencesInput(QDialog):
         self.update_line_edit_renderer_font_size()
         self.update_show_open_pulse_logo_checkbox()
         self.update_show_reference_scalebar_checkbox()
+        self.update_compatibility_mode_checkbox()
 
     def keyPressEvent(self, event):
         if event.key() == Qt.Key_Enter or event.key() == Qt.Key_Return:

--- a/pulse/interface/user_preferences.py
+++ b/pulse/interface/user_preferences.py
@@ -14,6 +14,7 @@ class UserPreferences:
     renderer_font_size: int  = 12
     show_open_pulse_logo : bool = True
     show_reference_scale_bar: bool = True
+    compatibility_mode: bool = False   
     color_map = "jet"
 
     def set_light_theme(self):

--- a/pulse/interface/viewer_3d/actors/editor_actors/point_actors/control_points_actor.py
+++ b/pulse/interface/viewer_3d/actors/editor_actors/point_actors/control_points_actor.py
@@ -1,5 +1,6 @@
 from molde.poly_data import VerticesData
 from vtkmodules.vtkRenderingCore import vtkActor, vtkPolyDataMapper
+from pulse import app
 
 
 class ControlPointsActor(vtkActor):
@@ -16,7 +17,8 @@ class ControlPointsActor(vtkActor):
         self.SetMapper(mapper)
 
         self.GetProperty().SetPointSize(15)
-        self.GetProperty().RenderPointsAsSpheresOn()
+        if not app().main_window.config.user_preferences.compatibility_mode:
+            self.GetProperty().RenderPointsAsSpheresOn()
         self.GetProperty().SetColor([i / 255 for i in (255, 180, 50)])
         self.GetProperty().LightingOff()
 

--- a/pulse/interface/viewer_3d/actors/editor_points_actor.py
+++ b/pulse/interface/viewer_3d/actors/editor_points_actor.py
@@ -21,7 +21,8 @@ class EditorPointsActor(GhostActor):
         self.SetMapper(mapper)
 
         self.GetProperty().SetPointSize(15)
-        self.GetProperty().RenderPointsAsSpheresOn()
+        if not app().main_window.config.user_preferences.compatibility_mode:
+            self.GetProperty().RenderPointsAsSpheresOn()
         editor_points_color = self.user_preferences.nodes_points_color.to_rgb()
         self.GetProperty().SetColor([i / 255 for i in editor_points_color])
         self.GetProperty().LightingOff()

--- a/pulse/interface/viewer_3d/actors/editor_selected_points_actor.py
+++ b/pulse/interface/viewer_3d/actors/editor_selected_points_actor.py
@@ -20,7 +20,8 @@ class EditorSelectedPointsActor(GhostActor):
         self.SetMapper(mapper)
 
         self.GetProperty().SetPointSize(15)
-        self.GetProperty().RenderPointsAsSpheresOn()
+        if not app().main_window.config.user_preferences.compatibility_mode:
+            self.GetProperty().RenderPointsAsSpheresOn()
         self.GetProperty().SetColor([i / 255 for i in (255, 50, 50)])
         self.GetProperty().LightingOff()
         self.make_ghost()

--- a/pulse/interface/viewer_3d/actors/nodes_actor.py
+++ b/pulse/interface/viewer_3d/actors/nodes_actor.py
@@ -48,7 +48,8 @@ class NodesActor(GhostActor):
 
         self.SetMapper(mapper)
         self.GetProperty().SetPointSize(10)
-        self.GetProperty().RenderPointsAsSpheresOn()
+        if not app().main_window.config.user_preferences.compatibility_mode:
+            self.GetProperty().RenderPointsAsSpheresOn()
         self.make_ghost()
         
         self.clear_colors()

--- a/pulse/interface/viewer_3d/actors/points_actor.py
+++ b/pulse/interface/viewer_3d/actors/points_actor.py
@@ -44,7 +44,8 @@ class PointsActor(GhostActor):
         
         self.SetMapper(mapper)
         self.GetProperty().SetPointSize(15)
-        self.GetProperty().RenderPointsAsSpheresOn()
+        if not app().main_window.config.user_preferences.compatibility_mode:
+            self.GetProperty().RenderPointsAsSpheresOn()
         self.make_ghost()
 
         self.clear_colors()

--- a/pulse/project/config.py
+++ b/pulse/project/config.py
@@ -27,6 +27,7 @@ class Config:
                 self.user_preferences.renderer_font_size = user_preferences["renderer_font_size"]
                 self.user_preferences.show_open_pulse_logo = user_preferences["show_open_pulse_logo"]
                 self.user_preferences.show_reference_scale_bar = user_preferences["show_reference_scale_bar"]
+                self.user_preferences.compatibility_mode = user_preferences["compatibility_mode"]
                 self.user_preferences.color_map = user_preferences["color_map"]
 
         except:
@@ -44,6 +45,7 @@ class Config:
         "renderer_font_size" : self.user_preferences.renderer_font_size,
         "show_open_pulse_logo" : self.user_preferences.show_open_pulse_logo,
         "show_reference_scale_bar" : self.user_preferences.show_reference_scale_bar,
+        "compatibility_mode" : self.user_preferences.compatibility_mode,
         "color_map" : self.user_preferences.color_map
         }
         
@@ -62,6 +64,7 @@ class Config:
         data["renderer_font_size"] = self.user_preferences.renderer_font_size
         data["show_open_pulse_logo"] = self.user_preferences.show_open_pulse_logo
         data["show_reference_scale_bar"] = self.user_preferences.show_reference_scale_bar
+        data["compatibility_mode"] = self.user_preferences.compatibility_mode
         data["color_map"] = self.user_preferences.color_map
 
         self.write_data_in_file(data)


### PR DESCRIPTION
This PR adds a functionality to make points viewable for some computers, mostly with Ryzen processors, that cannot view vtk points if the method RenderPointsAsShperesOn is used. Also, some methods are refactored for clarity.