### PR TITLE
Close or minimize dialogs

### DIFF
--- a/pulse/launch.py
+++ b/pulse/launch.py
@@ -1,8 +1,10 @@
-import sys, os, platform
-from vtkmodules.vtkCommonCore import vtkObject, vtkLogger
-# import qdarktheme
 import logging
+import os
+import platform
+import sys
 from traceback import format_tb
+
+from vtkmodules.vtkCommonCore import vtkLogger, vtkObject
 
 from pulse import USER_PATH
 from pulse.interface.application import Application
@@ -83,8 +85,8 @@ def main():
     # Make the window scale evenly for every monitor
     os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
 
-    if platform.system() == "Windows":
-        sys.argv.append("--platform")
+    if platform.system() == "Linux":
+        os.environ["QT_QPA_PLATFORM"] = "xcb"
 
     app = Application(sys.argv)
     sys.exit(app.exec_())


### PR DESCRIPTION
This PR updates the `MainWindow.close_dialogs` function to work for any open window.
It also adds functions to minimize and restore these dialogs.
Besides that, some small fixes were made so it works better on Linux without looking weird on other systems.

I have tested it on both Fedora Linux and Windows 11. It seems that everything is working well out of the box, but more tests are recommended.