### PR TITLE
Improve animation cache efficiency

### DIFF
--- a/pulse/interface/viewer_3d/render_widgets/_model_info_text.py
+++ b/pulse/interface/viewer_3d/render_widgets/_model_info_text.py
@@ -101,7 +101,9 @@ def nodes_info_text() -> str:
         if key in properties.nodal_properties.keys():
             data = properties.nodal_properties[key]
 
+            impedance_label = ""
             impedance_type = data.get("impedance_type")
+
             if impedance_type == RadiationImpedanceType.ANECHOIC:
                 impedance_label = "anechoic termination"
             elif impedance_type == RadiationImpedanceType.FLANGED:
@@ -109,7 +111,7 @@ def nodes_info_text() -> str:
             elif impedance_type == RadiationImpedanceType.UNFLANGED:
                 impedance_label = "unflanged pipe"
 
-            if isinstance(impedance_type, str):
+            if impedance_label != "":
                 info_text += _acoustic_format("Radiation impedance", impedance_label, "Type", "")
 
         key = ("reciprocating_compressor_excitation", node_id)

--- a/pulse/interface/viewer_3d/render_widgets/results_render_widget.py
+++ b/pulse/interface/viewer_3d/render_widgets/results_render_widget.py
@@ -69,6 +69,7 @@ class ResultsRenderWidget(AnimatedRenderWidget):
         self.current_phase_step = 0
         self._result_min = 0
         self._result_max = 0
+        self.is_complex_result = False
 
         self._animation_color_map = None
         self._animation_current_frequency = None
@@ -125,7 +126,7 @@ class ResultsRenderWidget(AnimatedRenderWidget):
                 unit_label = "Unit: [--]"
 
             deformed = True
-            color_table = self._compute_displacement_field(
+            color_table, self.is_complex_result = self._compute_displacement_field(
                 self.current_frequency_index,
                 self.current_phase_step,
             )
@@ -136,7 +137,7 @@ class ResultsRenderWidget(AnimatedRenderWidget):
                 unit_label = "Unit: [Pa]"
 
             deformed = True
-            color_table = self._compute_stress_field(
+            color_table, self.is_complex_result = self._compute_stress_field(
                 self.current_frequency_index,
                 self.current_phase_step,
             )
@@ -149,7 +150,7 @@ class ResultsRenderWidget(AnimatedRenderWidget):
             elif analysis_id == AnalysisID.ACOUSTIC_MODAL:
                 unit_label = "Unit: [--]"
 
-            color_table = self._compute_pressure_field(
+            color_table, self.is_complex_result = self._compute_pressure_field(
                 self.current_frequency_index,
                 self.current_phase_step,
             )
@@ -205,6 +206,9 @@ class ResultsRenderWidget(AnimatedRenderWidget):
 
         with self.update_lock:
             for frame in range(self._animation_total_frames):
+                if frame in self._animation_cached_data:
+                    continue
+
                 logging.info(f"Caching animation frames [{frame}/{self._animation_total_frames}]")
                 d_theta = 2 * np.pi / self._animation_total_frames
                 phase_step = frame * d_theta
@@ -214,6 +218,11 @@ class ResultsRenderWidget(AnimatedRenderWidget):
                 cached = vtkPolyData()
                 cached.DeepCopy(self.tubes_actor.GetMapper().GetInput())
                 self._animation_cached_data[frame] = cached
+                
+                if not self.is_complex_result:
+                    mirrored_frame = self._animation_total_frames - frame - 1
+                    self._animation_cached_data[mirrored_frame] = self._animation_cached_data[frame]
+
         self._animation_current_cycle = 0
 
     def stop_animation(self):
@@ -569,7 +578,9 @@ class ResultsRenderWidget(AnimatedRenderWidget):
                                  self.colormap,
                                  )
 
-        return color_table
+        is_complex_result = np.imag(solution).any()
+
+        return color_table, is_complex_result
 
     def _compute_stress_field(self, frequency_index, phase_step):
         project = app().project
@@ -596,7 +607,9 @@ class ResultsRenderWidget(AnimatedRenderWidget):
                                  stress_field_plot = True,
                                  )
 
-        return color_table
+        is_complex_result = np.imag(solution).any()
+
+        return color_table, is_complex_result
 
     def _compute_pressure_field(self, frequency_index, phase_step):
 
@@ -618,7 +631,9 @@ class ResultsRenderWidget(AnimatedRenderWidget):
                                  pressure_field_plot=True,
                                 )
 
-        return color_table
+        is_complex_result = np.imag(solution).any()
+
+        return color_table, is_complex_result
 
     def _reset_min_max_values(self):
         self.count_cycles = 0

--- a/pulse/postprocessing/plot_acoustic_data.py
+++ b/pulse/postprocessing/plot_acoustic_data.py
@@ -128,8 +128,9 @@ def get_acoustic_response(preprocessor, solution, column, **kwargs):
 
     _pressures = np.abs(data)
     _phases = np.angle(data)
+    _delta = -_phases[np.argmax(_pressures)]
 
-    pressures_plot = _pressures*np.cos(_phases + phase_step)
+    pressures_plot = _pressures*np.cos(_phases + phase_step + _delta)
     
     if absolute_animation:
         pressures_plot = np.abs(pressures_plot)

--- a/pulse/postprocessing/plot_structural_data.py
+++ b/pulse/postprocessing/plot_structural_data.py
@@ -195,6 +195,9 @@ def get_structural_response(preprocessor: "Preprocessor", solution: np.ndarray, 
     phases = np.angle(solution)
     _phases = np.array([phases[ind+0, column], phases[ind+1, column], phases[ind+2, column], 
                         phases[ind+3, column], phases[ind+4, column], phases[ind+5, column]]).T
+    
+    _idx_max = np.argmax(np.abs(solution[:, column]))
+    _delta = -np.angle(solution[_idx_max, column])
 
     if new_scf is None:
         scf = preprocessor.structure_principal_diagonal / 50
@@ -213,7 +216,7 @@ def get_structural_response(preprocessor: "Preprocessor", solution: np.ndarray, 
     if phase_step is None:
         factor = magnif_factor
     else:
-        factor = magnif_factor*np.cos(phase_step + _phases)
+        factor = magnif_factor*np.cos(phase_step + _phases + _delta)
     
     coord_def[:,0] = coord[:,0]
     coord_def[:,1] = coord[:,1] + np.abs(u_x)*factor[:, 0]


### PR DESCRIPTION
This PR makes the animations more than twice as fast by caching only half of the frames when the solution is real. Additionally, it ensures that when a frequency is selected, the plot immediately displays the frame corresponding to the maximum response.

This optimization was previously implemented in VIBRA (https://github.com/MOPT-UFSC/VIBRA/pull/181) and is now being ported to OP.

Closes #327 