### PR TITLE
Fix geometry designer widget bug

### DIFF
--- a/pulse/interface/user_input/model/geometry/geometry_designer_widget.py
+++ b/pulse/interface/user_input/model/geometry/geometry_designer_widget.py
@@ -724,6 +724,11 @@ class GeometryDesignerWidget(GeometryDesignerWidget_UI):
         app().main_window.plot_lines_with_cross_sections()
         self.render_widget.set_info_text("")
 
+    def reject(self):
+        # QDialog.reject() calls hide() when Esc is pressed, which makes the
+        # widget disappear when embedded in a QStackedWidget. Override to no-op.
+        pass
+
     def showEvent(self, event):
         self._update_permissions()
 


### PR DESCRIPTION
This PR contains a fix to the geometry designer widget.

When we are in the geometry editor, if we click in the editor widget and press Esc, the content of the widget dissapears:

<img width="1873" height="826" alt="image" src="https://github.com/user-attachments/assets/3ed025c0-ab7f-4f48-af6f-4fbdb45faadc" />

<img width="1873" height="826" alt="image" src="https://github.com/user-attachments/assets/0ce475ff-9ac0-41fb-b910-08bfb96cf99c" />

To solve this problem, I just override the reject method from the `GeometryDesignerWidget` class.

