### PR TITLE
Review the render actors

### DIFF
--- a/pulse/interface/viewer_3d/actors/tube_actor.py
+++ b/pulse/interface/viewer_3d/actors/tube_actor.py
@@ -16,6 +16,9 @@ from vtkmodules.vtkRenderingCore import vtkActor, vtkGlyph3DMapper
 from pulse import app
 from pulse.utils.interface_utils import ColorMode
 from pulse.interface.viewer_3d.coloring.color_table import ColorTable
+from pulse.model.acoustic_element import AcousticElement
+from pulse.model.structural_element import StructuralElement
+from pulse.model.cross_section import CrossSection
 
 
 class TubeActor(vtkActor):
@@ -106,17 +109,17 @@ class TubeActor(vtkActor):
         
         self.clear_colors()
 
-    def get_element_coordinates(self, element) -> tuple[float, float, float]:
+    def get_element_coordinates(self, element: AcousticElement | StructuralElement) -> tuple[float, float, float]:
         return element.first_node.coordinates
 
-    def get_element_rotations(self, element) -> tuple[float, float, float]:
+    def get_element_rotations(self, element: AcousticElement | StructuralElement) -> tuple[float, float, float]:
         return element.section_rotation_xyz_undeformed
 
-    def create_element_data(self, element):
+    def create_element_data(self, element: AcousticElement | StructuralElement):
         cross_section = element.cross_section
-        if cross_section is None:
+        if not isinstance(cross_section, CrossSection):
             return vtkPolyData()
-        
+
         tube_sides = self._get_tube_sides()
         length = element.length
 
@@ -321,19 +324,8 @@ class TubeActor(vtkActor):
         if source is None:
             return vtkPolyData()
 
-        # transform = vtkTransform()
-        # transform.RotateZ(-90)
-        # transform.RotateY(90)
-        # transform.Update()
-
-        # transform_filter = vtkTransformFilter()
-        # transform_filter.SetInputData(source)
-        # transform_filter.SetTransform(transform)
-        # transform_filter.Update()
-
         normals_filter = vtkPolyDataNormals()
         normals_filter.AddInputData(source)
-        # normals_filter.AddInputData(transform_filter.GetOutput())
         normals_filter.Update()
 
         return normals_filter.GetOutput()

--- a/pulse/interface/viewer_3d/actors/tube_actor.py
+++ b/pulse/interface/viewer_3d/actors/tube_actor.py
@@ -68,7 +68,6 @@ class TubeActor(vtkActor):
         colors.Fill(255)
         colors.SetName("colors")
 
-
         section_index = dict()
         for element in visible_elements.values():
             points.InsertNextPoint(self.get_element_coordinates(element))
@@ -127,9 +126,7 @@ class TubeActor(vtkActor):
 
         elif cross_section.section_type_label == "rectangular_beam":
             b, h, b_in, h_in, offset_y, offset_z, *_ = element.section_parameters_render
-            t0 = (b - b_in) / 2
-            t1 = (h - h_in) / 2
-            return cross_section_sources.rectangular_beam_data(length, b, h, t0, t1, offset_y=offset_y, offset_z=offset_z)
+            return cross_section_sources.rectangular_beam_data(length, b, h, b_in, h_in, offset_y=offset_y, offset_z=offset_z)
 
         elif cross_section.section_type_label == "circular_beam":
             d_out, t, offset_y, offset_z, *_ = element.section_parameters_render
@@ -324,18 +321,19 @@ class TubeActor(vtkActor):
         if source is None:
             return vtkPolyData()
 
-        transform = vtkTransform()
-        transform.RotateZ(-90)
-        transform.RotateY(90)
-        transform.Update()
+        # transform = vtkTransform()
+        # transform.RotateZ(-90)
+        # transform.RotateY(90)
+        # transform.Update()
 
-        transform_filter = vtkTransformFilter()
-        transform_filter.SetInputData(source)
-        transform_filter.SetTransform(transform)
-        transform_filter.Update()
+        # transform_filter = vtkTransformFilter()
+        # transform_filter.SetInputData(source)
+        # transform_filter.SetTransform(transform)
+        # transform_filter.Update()
 
         normals_filter = vtkPolyDataNormals()
-        normals_filter.AddInputData(transform_filter.GetOutput())
+        normals_filter.AddInputData(source)
+        # normals_filter.AddInputData(transform_filter.GetOutput())
         normals_filter.Update()
 
         return normals_filter.GetOutput()

--- a/pulse/model/cross_sections/t_beam_cross_section.py
+++ b/pulse/model/cross_sections/t_beam_cross_section.py
@@ -70,7 +70,7 @@ class TBeamCrossSection:
     @property
     def section_points_to_draw(self):
 
-        h, w1, tw, t1, offset_y, offset_z = self.section_parameters
+        h, w1, t1, tw, offset_y, offset_z = self.section_parameters
         hw = h - t1
 
         Zp_right = [0, tw/2, tw/2, w1/2, w1/2, 0]

--- a/pulse/utils/cross_section_sources.py
+++ b/pulse/utils/cross_section_sources.py
@@ -217,7 +217,7 @@ def i_beam_data(length, h, w1, w2, t1, t2, tw, offset_y=0, offset_z=0):
     rectangular_top.Update()
 
     rectangular_center.SetXLength(length)
-    rectangular_center.SetYLength(h - (t1 + t2))
+    rectangular_center.SetYLength(h)
     rectangular_center.SetZLength(tw)
     rectangular_center.SetCenter(length / 2, -Yc + offset_y, -Zc + offset_z)
     rectangular_center.Update()

--- a/pulse/utils/cross_section_sources.py
+++ b/pulse/utils/cross_section_sources.py
@@ -41,7 +41,6 @@ def apply_transform(data, dx=0, dy=0, dz=0, rx=0, ry=0, rz=0, sx=1, sy=1, sz=1):
 
 VALVE_WHEEL = load_symbol(SYMBOLS_DIR / "other/valve_wheel.obj")
 
-
 def closed_pipe_data(length, outside_diameter, offset_y=0, offset_z=0, sides=20):
     cilinder = vtkCylinderSource()
     cilinder.SetResolution(sides)
@@ -51,7 +50,6 @@ def closed_pipe_data(length, outside_diameter, offset_y=0, offset_z=0, sides=20)
     cilinder.CappingOn()
     cilinder.Update()
     return apply_transform(cilinder.GetOutput(), rz=-90)
-
 
 def pipe_data(length, outside_diameter, thickness, offset_y=0, offset_z=0, sides=20):
     if (thickness == 0) or (2 * thickness > outside_diameter):
@@ -101,7 +99,6 @@ def pipe_data(length, outside_diameter, thickness, offset_y=0, offset_z=0, sides
 
     return apply_transform(append_polydata.GetOutput(), rz=-90)
 
-
 def circular_beam_data(length, outside_diameter, thickness, offset_y=0, offset_z=0):
     cilinder = vtkCylinderSource()
     cilinder.SetResolution(12)
@@ -113,7 +110,6 @@ def circular_beam_data(length, outside_diameter, thickness, offset_y=0, offset_z
 
     return apply_transform(cilinder.GetOutput(), rz=-90)
 
-
 def closed_rectangular_beam_data(length, b, h, offset_y=0, offset_z=0):
     rectangle = vtkCubeSource()
     rectangle.SetXLength(length)
@@ -121,8 +117,8 @@ def closed_rectangular_beam_data(length, b, h, offset_y=0, offset_z=0):
     rectangle.SetZLength(b)
     rectangle.SetCenter(length / 2, offset_y, offset_z)
     rectangle.Update()
-    return rectangle.GetOutput()
 
+    return rectangle.GetOutput()
 
 def rectangular_beam_data(length, b, h, b_in, h_in, offset_y=0, offset_z=0):
 
@@ -170,7 +166,6 @@ def rectangular_beam_data(length, b, h, b_in, h_in, offset_y=0, offset_z=0):
 
     return append_polydata.GetOutput()
 
-
 def c_beam_data(length, h, w1, w2, t1, t2, tw, offset_y=0, offset_z=0):
 
     Zc, Yc = CBeamCrossSection(h, w1, t1, w2, t2, tw, offset_y, offset_z).centroid
@@ -183,19 +178,18 @@ def c_beam_data(length, h, w1, w2, t1, t2, tw, offset_y=0, offset_z=0):
     rectangular_top.SetYLength(t1)
     rectangular_top.SetZLength(w1)
     rectangular_top.SetCenter(length / 2, h / 2 - t1 / 2 + offset_y - Yc, (w1 / 2) - Zc + offset_z)
+    rectangular_top.Update()
 
     rectangular_left.SetXLength(length)
     rectangular_left.SetYLength(h)
     rectangular_left.SetZLength(tw)
     rectangular_left.SetCenter(length / 2, -Yc + offset_y, (tw / 2) - Zc + offset_z)
+    rectangular_left.Update()
 
     rectangular_bottom.SetXLength(length)
     rectangular_bottom.SetYLength(t2)
     rectangular_bottom.SetZLength(w2)
     rectangular_bottom.SetCenter(length / 2, -h / 2 + t2 / 2 + offset_y - Yc,  (w2 / 2) - Zc + offset_z)
-
-    rectangular_top.Update()
-    rectangular_left.Update()
     rectangular_bottom.Update()
 
     append_polydata = vtkAppendPolyData()
@@ -205,7 +199,6 @@ def c_beam_data(length, h, w1, w2, t1, t2, tw, offset_y=0, offset_z=0):
     append_polydata.Update()
 
     return append_polydata.GetOutput()
-
 
 def i_beam_data(length, h, w1, w2, t1, t2, tw, offset_y=0, offset_z=0):
 
@@ -219,19 +212,18 @@ def i_beam_data(length, h, w1, w2, t1, t2, tw, offset_y=0, offset_z=0):
     rectangular_top.SetYLength(t1)
     rectangular_top.SetZLength(w1)
     rectangular_top.SetCenter(length / 2, h / 2 - t1 / 2 - Yc + offset_y, -Zc + offset_z)
+    rectangular_top.Update()
 
     rectangular_center.SetXLength(length)
-    rectangular_center.SetYLength(h)
+    rectangular_center.SetYLength(h - (t1 + t2))
     rectangular_center.SetZLength(tw)
     rectangular_center.SetCenter(length / 2, -Yc + offset_y, -Zc + offset_z)
+    rectangular_center.Update()
 
     rectangular_bottom.SetXLength(length)
     rectangular_bottom.SetYLength(t2)
     rectangular_bottom.SetZLength(w2)
     rectangular_bottom.SetCenter(length / 2, -h / 2 + t2 / 2 - Yc + offset_y, -Zc + offset_z)
-
-    rectangular_top.Update()
-    rectangular_center.Update()
     rectangular_bottom.Update()
 
     append_polydata = vtkAppendPolyData()
@@ -241,7 +233,6 @@ def i_beam_data(length, h, w1, w2, t1, t2, tw, offset_y=0, offset_z=0):
     append_polydata.Update()
 
     return append_polydata.GetOutput()
-
 
 def t_beam_data(length, h, w1, t1, tw, offset_y=0, offset_z=0):
 
@@ -255,13 +246,12 @@ def t_beam_data(length, h, w1, t1, tw, offset_y=0, offset_z=0):
     rectangular_top.SetYLength(t1)
     rectangular_top.SetZLength(w1)
     rectangular_top.SetCenter(length / 2, (hw - t1) / 2 - Yc + offset_y, -Zc + offset_z)
+    rectangular_top.Update()
 
     rectangular_center.SetXLength(length)
     rectangular_center.SetYLength(hw)
     rectangular_center.SetZLength(tw)
     rectangular_center.SetCenter(length / 2, - Yc + offset_y, -Zc + offset_z)
-
-    rectangular_top.Update()
     rectangular_center.Update()
 
     append_polydata = vtkAppendPolyData()
@@ -271,7 +261,6 @@ def t_beam_data(length, h, w1, t1, tw, offset_y=0, offset_z=0):
     append_polydata.SetObjectName("t_beam_data")
 
     return append_polydata.GetOutput()
-
 
 def reducer_data(
     length,
@@ -333,7 +322,6 @@ def reducer_data(
     return apply_transform(append_polydata.GetOutput(), rz=-90)
     # return append_polydata.GetOutput()
 
-
 def flange_data(length, outside_diameter, thickness, n_bolts=8, offset_y=0, offset_z=0):
     pipe = closed_pipe_data(length, outside_diameter, offset_y, offset_z)
     append_polydata = vtkAppendPolyData()
@@ -357,7 +345,6 @@ def flange_data(length, outside_diameter, thickness, n_bolts=8, offset_y=0, offs
 
     return apply_transform(append_polydata.GetOutput(), rz=-90)
     # return append_polydata.GetOutput()
-
 
 def expansion_joint_data(length, outside_diameter, thickness):
     append_polydata = vtkAppendPolyData()
@@ -427,7 +414,6 @@ def expansion_joint_data(length, outside_diameter, thickness):
     return apply_transform(append_polydata.GetOutput(), rz=-90)
     # return append_polydata.GetOutput()
 
-
 def valve_data(length, outside_diameter, thickness, flange_diameter, flange_length):
     append_polydata = vtkAppendPolyData()
 
@@ -450,7 +436,6 @@ def valve_data(length, outside_diameter, thickness, flange_diameter, flange_leng
 
     return apply_transform(append_polydata.GetOutput(), rz=-90)
     # return append_polydata.GetOutput()
-
 
 def valve_handle(outside_diameter):
     height = 1.5 * outside_diameter

--- a/pulse/utils/cross_section_sources.py
+++ b/pulse/utils/cross_section_sources.py
@@ -172,6 +172,9 @@ def c_beam_data(length, h, w1, w2, t1, t2, tw, offset_y=0, offset_z=0):
 
     Zc, Yc = CBeamCrossSection(h, w1, t1, w2, t2, tw, offset_y, offset_z).centroid
 
+    # compute the y coordinate centroid for the left rectangle of the C-Beam
+    y_left = (((h/2 - t1)**2) - ((h/2 - t2)**2))*(tw/2) / ((h-(t1+t2))*tw)
+
     rectangular_top = vtkCubeSource()
     rectangular_left = vtkCubeSource()
     rectangular_bottom = vtkCubeSource()
@@ -179,19 +182,19 @@ def c_beam_data(length, h, w1, w2, t1, t2, tw, offset_y=0, offset_z=0):
     rectangular_top.SetXLength(length)
     rectangular_top.SetYLength(t1)
     rectangular_top.SetZLength(w1)
-    rectangular_top.SetCenter(length / 2, h / 2 - t1 / 2 + offset_y - Yc, (w1 / 2) - Zc + offset_z)
+    rectangular_top.SetCenter(length / 2, (h - t1) / 2 + offset_y - Yc, (w1 / 2) - Zc + offset_z)
     rectangular_top.Update()
 
     rectangular_left.SetXLength(length)
-    rectangular_left.SetYLength(h)
+    rectangular_left.SetYLength(h - (t1 + t2))
     rectangular_left.SetZLength(tw)
-    rectangular_left.SetCenter(length / 2, -Yc + offset_y, (tw / 2) - Zc + offset_z)
+    rectangular_left.SetCenter(length / 2, y_left - Yc + offset_y, (tw / 2) - Zc + offset_z)
     rectangular_left.Update()
 
     rectangular_bottom.SetXLength(length)
     rectangular_bottom.SetYLength(t2)
     rectangular_bottom.SetZLength(w2)
-    rectangular_bottom.SetCenter(length / 2, -h / 2 + t2 / 2 + offset_y - Yc,  (w2 / 2) - Zc + offset_z)
+    rectangular_bottom.SetCenter(length / 2, -(h - t2) / 2 + offset_y - Yc,  (w2 / 2) - Zc + offset_z)
     rectangular_bottom.Update()
 
     append_polydata = vtkAppendPolyData()
@@ -206,6 +209,9 @@ def i_beam_data(length, h, w1, w2, t1, t2, tw, offset_y=0, offset_z=0):
 
     Zc, Yc = IBeamCrossSection(h, w1, t1, w2, t2, tw, offset_y, offset_z).centroid
 
+    # compute the y coordinate centroid for the center rectangle of the I-Beam
+    y_center = (((h/2 - t1)**2) - ((h/2 - t2)**2))*(tw/2) / ((h-(t1+t2))*tw)
+
     rectangular_top = vtkCubeSource()
     rectangular_center = vtkCubeSource()
     rectangular_bottom = vtkCubeSource()
@@ -213,19 +219,19 @@ def i_beam_data(length, h, w1, w2, t1, t2, tw, offset_y=0, offset_z=0):
     rectangular_top.SetXLength(length)
     rectangular_top.SetYLength(t1)
     rectangular_top.SetZLength(w1)
-    rectangular_top.SetCenter(length / 2, h / 2 - t1 / 2 - Yc + offset_y, -Zc + offset_z)
+    rectangular_top.SetCenter(length / 2, (h - t1) / 2 - Yc + offset_y, -Zc + offset_z)
     rectangular_top.Update()
 
     rectangular_center.SetXLength(length)
-    rectangular_center.SetYLength(h)
+    rectangular_center.SetYLength(h - (t1+t2))
     rectangular_center.SetZLength(tw)
-    rectangular_center.SetCenter(length / 2, -Yc + offset_y, -Zc + offset_z)
+    rectangular_center.SetCenter(length / 2, y_center - Yc + offset_y, -Zc + offset_z)
     rectangular_center.Update()
 
     rectangular_bottom.SetXLength(length)
     rectangular_bottom.SetYLength(t2)
     rectangular_bottom.SetZLength(w2)
-    rectangular_bottom.SetCenter(length / 2, -h / 2 + t2 / 2 - Yc + offset_y, -Zc + offset_z)
+    rectangular_bottom.SetCenter(length / 2, -(h - t2) / 2 - Yc + offset_y, -Zc + offset_z)
     rectangular_bottom.Update()
 
     append_polydata = vtkAppendPolyData()

--- a/pulse/utils/cross_section_sources.py
+++ b/pulse/utils/cross_section_sources.py
@@ -15,7 +15,9 @@ from vtkmodules.vtkFiltersSources import (
 from vtkmodules.vtkIOGeometry import vtkOBJReader
 
 from pulse import SYMBOLS_DIR
-
+from pulse.model.cross_sections.c_beam_cross_section import CBeamCrossSection
+from pulse.model.cross_sections.i_beam_cross_section import IBeamCrossSection
+from pulse.model.cross_sections.t_beam_cross_section import TBeamCrossSection
 
 def load_symbol(path):
     reader = vtkOBJReader()
@@ -44,11 +46,11 @@ def closed_pipe_data(length, outside_diameter, offset_y=0, offset_z=0, sides=20)
     cilinder = vtkCylinderSource()
     cilinder.SetResolution(sides)
     cilinder.SetRadius(outside_diameter / 2)
-    cilinder.SetCenter(offset_y, length / 2, offset_z)
+    cilinder.SetCenter(offset_z, length / 2, offset_y)
     cilinder.SetHeight(length)
     cilinder.CappingOn()
     cilinder.Update()
-    return cilinder.GetOutput()
+    return apply_transform(cilinder.GetOutput(), rz=-90)
 
 
 def pipe_data(length, outside_diameter, thickness, offset_y=0, offset_z=0, sides=20):
@@ -62,7 +64,7 @@ def pipe_data(length, outside_diameter, thickness, offset_y=0, offset_z=0, sides
     outer_cilinder.SetResolution(sides)
     outer_cilinder.SetRadius(outer_radius)
     outer_cilinder.SetHeight(length)
-    outer_cilinder.SetCenter(offset_y, length / 2, offset_z)
+    outer_cilinder.SetCenter(offset_z, length / 2, offset_y)
     outer_cilinder.CappingOff()
     outer_cilinder.Update()
 
@@ -70,7 +72,7 @@ def pipe_data(length, outside_diameter, thickness, offset_y=0, offset_z=0, sides
     inner_cilinder.SetResolution(sides)
     inner_cilinder.SetRadius(inner_radius)
     inner_cilinder.SetHeight(length)
-    inner_cilinder.SetCenter(offset_y, length / 2, offset_z)
+    inner_cilinder.SetCenter(offset_z, length / 2, offset_y)
     inner_cilinder.CappingOff()
     inner_cilinder.Update()
 
@@ -78,7 +80,7 @@ def pipe_data(length, outside_diameter, thickness, offset_y=0, offset_z=0, sides
     ring_bottom.SetCircumferentialResolution(sides)
     ring_bottom.SetOuterRadius(outer_radius)
     ring_bottom.SetInnerRadius(inner_radius)
-    ring_bottom.SetCenter(offset_y, 0, offset_z)
+    ring_bottom.SetCenter(offset_z, 0, offset_y)
     ring_bottom.SetNormal(0, 1, 0)
     ring_bottom.Update()
 
@@ -86,7 +88,7 @@ def pipe_data(length, outside_diameter, thickness, offset_y=0, offset_z=0, sides
     ring_top.SetCircumferentialResolution(sides)
     ring_top.SetOuterRadius(outer_radius)
     ring_top.SetInnerRadius(inner_radius)
-    ring_top.SetCenter(offset_y, length, offset_z)
+    ring_top.SetCenter(offset_z, length, offset_y)
     ring_top.SetNormal(0, 1, 0)
     ring_top.Update()
 
@@ -97,7 +99,7 @@ def pipe_data(length, outside_diameter, thickness, offset_y=0, offset_z=0, sides
     append_polydata.AddInputData(ring_top.GetOutput())
     append_polydata.Update()
 
-    return append_polydata.GetOutput()
+    return apply_transform(append_polydata.GetOutput(), rz=-90)
 
 
 def circular_beam_data(length, outside_diameter, thickness, offset_y=0, offset_z=0):
@@ -105,24 +107,29 @@ def circular_beam_data(length, outside_diameter, thickness, offset_y=0, offset_z
     cilinder.SetResolution(12)
     cilinder.SetRadius(outside_diameter / 2)
     cilinder.SetHeight(length)
-    cilinder.SetCenter(offset_y, length / 2, offset_z)
+    cilinder.SetCenter(offset_z, length / 2, offset_y)
     cilinder.CappingOn()
     cilinder.Update()
-    return cilinder.GetOutput()
+
+    return apply_transform(cilinder.GetOutput(), rz=-90)
 
 
 def closed_rectangular_beam_data(length, b, h, offset_y=0, offset_z=0):
     rectangle = vtkCubeSource()
-    rectangle.SetYLength(length)
-    rectangle.SetXLength(b)
-    rectangle.SetZLength(h)
-    rectangle.SetCenter(offset_y, length / 2, offset_z)
+    rectangle.SetXLength(length)
+    rectangle.SetYLength(h)
+    rectangle.SetZLength(b)
+    rectangle.SetCenter(length / 2, offset_y, offset_z)
     rectangle.Update()
     return rectangle.GetOutput()
 
 
-def rectangular_beam_data(length, b, h, t0, t1, offset_y=0, offset_z=0):
-    if t0 == 0 or t1 == 0:
+def rectangular_beam_data(length, b, h, b_in, h_in, offset_y=0, offset_z=0):
+
+    tb = (b - b_in) / 2
+    th = (h - h_in) / 2
+
+    if tb == 0 or th == 0:
         return closed_rectangular_beam_data(length, b, h, offset_y, offset_z)
 
     rectangular_top = vtkCubeSource()
@@ -130,29 +137,28 @@ def rectangular_beam_data(length, b, h, t0, t1, offset_y=0, offset_z=0):
     rectangular_right = vtkCubeSource()
     rectangular_bottom = vtkCubeSource()
 
-    rectangular_top.SetYLength(length)
-    rectangular_top.SetZLength(t1)
-    rectangular_top.SetXLength(b)
-    rectangular_top.SetCenter(offset_y, length / 2, -h / 2 + t1 / 2 + offset_z)
-
-    rectangular_left.SetYLength(length)
-    rectangular_left.SetZLength(h)
-    rectangular_left.SetXLength(t0)
-    rectangular_left.SetCenter(offset_y - b / 2 + t0 / 2, length / 2, offset_z)
-
-    rectangular_right.SetYLength(length)
-    rectangular_right.SetZLength(h)
-    rectangular_right.SetXLength(t0)
-    rectangular_right.SetCenter(offset_y + b / 2 - t0 / 2, length / 2, offset_z)
-
-    rectangular_bottom.SetYLength(length)
-    rectangular_bottom.SetZLength(t1)
-    rectangular_bottom.SetXLength(b)
-    rectangular_bottom.SetCenter(offset_y, length / 2, h / 2 - t1 / 2 + offset_z)
-
+    rectangular_top.SetXLength(length)
+    rectangular_top.SetYLength(tb)
+    rectangular_top.SetZLength(b)
+    rectangular_top.SetCenter(length / 2, (h - tb) / 2 + offset_y, offset_z)
     rectangular_top.Update()
+
+    rectangular_left.SetXLength(length)
+    rectangular_left.SetYLength(h - 2*th)
+    rectangular_left.SetZLength(th)
+    rectangular_left.SetCenter(length / 2, offset_y, -(b - th) / 2 + offset_z)
     rectangular_left.Update()
+
+    rectangular_right.SetXLength(length)
+    rectangular_right.SetYLength(h - 2*th)
+    rectangular_right.SetZLength(th)
+    rectangular_right.SetCenter(length / 2, offset_y, (b - th) / 2 + offset_z)
     rectangular_right.Update()
+
+    rectangular_bottom.SetXLength(length)
+    rectangular_bottom.SetYLength(tb)
+    rectangular_bottom.SetZLength(b)
+    rectangular_bottom.SetCenter(length / 2, -(h - tb) / 2 + offset_y, offset_z)
     rectangular_bottom.Update()
 
     append_polydata = vtkAppendPolyData()
@@ -166,24 +172,27 @@ def rectangular_beam_data(length, b, h, t0, t1, offset_y=0, offset_z=0):
 
 
 def c_beam_data(length, h, w1, w2, t1, t2, tw, offset_y=0, offset_z=0):
+
+    Zc, Yc = CBeamCrossSection(h, w1, t1, w2, t2, tw, offset_y, offset_z).centroid
+
     rectangular_top = vtkCubeSource()
     rectangular_left = vtkCubeSource()
     rectangular_bottom = vtkCubeSource()
 
-    rectangular_top.SetYLength(length)
-    rectangular_top.SetZLength(t1)
-    rectangular_top.SetXLength(w1)
-    rectangular_top.SetCenter(offset_y + w1 / 2 - max(w1, w2) / 2, length / 2, -h / 2 + t1 / 2 + offset_z)
+    rectangular_top.SetXLength(length)
+    rectangular_top.SetYLength(t1)
+    rectangular_top.SetZLength(w1)
+    rectangular_top.SetCenter(length / 2, h / 2 - t1 / 2 + offset_y - Yc, (w1 / 2) - Zc + offset_z)
 
-    rectangular_left.SetYLength(length)
-    rectangular_left.SetZLength(h)
-    rectangular_left.SetXLength(tw)
-    rectangular_left.SetCenter(offset_y - max(w1, w2) / 2 + tw / 2, length / 2, offset_z)
+    rectangular_left.SetXLength(length)
+    rectangular_left.SetYLength(h)
+    rectangular_left.SetZLength(tw)
+    rectangular_left.SetCenter(length / 2, -Yc + offset_y, (tw / 2) - Zc + offset_z)
 
-    rectangular_bottom.SetYLength(length)
-    rectangular_bottom.SetZLength(t2)
-    rectangular_bottom.SetXLength(w2)
-    rectangular_bottom.SetCenter(offset_y + w2 / 2 - max(w1, w2) / 2, length / 2, h / 2 - t2 / 2 + offset_z)
+    rectangular_bottom.SetXLength(length)
+    rectangular_bottom.SetYLength(t2)
+    rectangular_bottom.SetZLength(w2)
+    rectangular_bottom.SetCenter(length / 2, -h / 2 + t2 / 2 + offset_y - Yc,  (w2 / 2) - Zc + offset_z)
 
     rectangular_top.Update()
     rectangular_left.Update()
@@ -199,24 +208,27 @@ def c_beam_data(length, h, w1, w2, t1, t2, tw, offset_y=0, offset_z=0):
 
 
 def i_beam_data(length, h, w1, w2, t1, t2, tw, offset_y=0, offset_z=0):
+
+    Zc, Yc = IBeamCrossSection(h, w1, t1, w2, t2, tw, offset_y, offset_z).centroid
+
     rectangular_top = vtkCubeSource()
     rectangular_center = vtkCubeSource()
     rectangular_bottom = vtkCubeSource()
 
-    rectangular_top.SetYLength(length)
-    rectangular_top.SetZLength(t1)
-    rectangular_top.SetXLength(w1)
-    rectangular_top.SetCenter(offset_y, length / 2, -h / 2 + t1 / 2 + offset_z)
+    rectangular_top.SetXLength(length)
+    rectangular_top.SetYLength(t1)
+    rectangular_top.SetZLength(w1)
+    rectangular_top.SetCenter(length / 2, h / 2 - t1 / 2 - Yc + offset_y, -Zc + offset_z)
 
-    rectangular_center.SetYLength(length)
-    rectangular_center.SetZLength(h)
-    rectangular_center.SetCenter(offset_y, length / 2, offset_z)
-    rectangular_center.SetXLength(tw)
+    rectangular_center.SetXLength(length)
+    rectangular_center.SetYLength(h)
+    rectangular_center.SetZLength(tw)
+    rectangular_center.SetCenter(length / 2, -Yc + offset_y, -Zc + offset_z)
 
-    rectangular_bottom.SetYLength(length)
-    rectangular_bottom.SetZLength(t2)
-    rectangular_bottom.SetXLength(w2)
-    rectangular_bottom.SetCenter(offset_y, length / 2, h / 2 - t2 / 2 + offset_z)
+    rectangular_bottom.SetXLength(length)
+    rectangular_bottom.SetYLength(t2)
+    rectangular_bottom.SetZLength(w2)
+    rectangular_bottom.SetCenter(length / 2, -h / 2 + t2 / 2 - Yc + offset_y, -Zc + offset_z)
 
     rectangular_top.Update()
     rectangular_center.Update()
@@ -232,18 +244,22 @@ def i_beam_data(length, h, w1, w2, t1, t2, tw, offset_y=0, offset_z=0):
 
 
 def t_beam_data(length, h, w1, t1, tw, offset_y=0, offset_z=0):
+
+    hw = h - t1
+    Zc, Yc = TBeamCrossSection(h, w1, t1, tw, offset_y, offset_z).centroid
+
     rectangular_top = vtkCubeSource()
     rectangular_center = vtkCubeSource()
 
-    rectangular_top.SetYLength(length)
-    rectangular_top.SetZLength(t1)
-    rectangular_top.SetXLength(w1)
-    rectangular_top.SetCenter(offset_y, length / 2, -h / 2 + t1 / 2 + offset_z)
+    rectangular_top.SetXLength(length)
+    rectangular_top.SetYLength(t1)
+    rectangular_top.SetZLength(w1)
+    rectangular_top.SetCenter(length / 2, (hw - t1) / 2 - Yc + offset_y, -Zc + offset_z)
 
-    rectangular_center.SetYLength(length)
-    rectangular_center.SetZLength(h)
-    rectangular_center.SetCenter(offset_y, length / 2, offset_z)
-    rectangular_center.SetXLength(tw)
+    rectangular_center.SetXLength(length)
+    rectangular_center.SetYLength(hw)
+    rectangular_center.SetZLength(tw)
+    rectangular_center.SetCenter(length / 2, - Yc + offset_y, -Zc + offset_z)
 
     rectangular_top.Update()
     rectangular_center.Update()
@@ -252,6 +268,7 @@ def t_beam_data(length, h, w1, t1, tw, offset_y=0, offset_z=0):
     append_polydata.AddInputData(rectangular_top.GetOutput())
     append_polydata.AddInputData(rectangular_center.GetOutput())
     append_polydata.Update()
+    append_polydata.SetObjectName("t_beam_data")
 
     return append_polydata.GetOutput()
 
@@ -273,14 +290,14 @@ def reducer_data(
     initial_ring = vtkRegularPolygonSource()
     initial_ring.SetRadius(initial_radius)
     initial_ring.SetNumberOfSides(sides)
-    initial_ring.SetCenter(initial_offset_y, 0, initial_offset_z)
+    initial_ring.SetCenter(initial_offset_z, 0, initial_offset_y)
     initial_ring.SetNormal(0, 1, 0)
     initial_ring.Update()
 
     final_ring = vtkRegularPolygonSource()
     final_ring.SetRadius(final_radius)
     final_ring.SetNumberOfSides(sides)
-    final_ring.SetCenter(final_offset_y, length, final_offset_z)
+    final_ring.SetCenter(final_offset_z, length, final_offset_y)
     final_ring.SetNormal(0, 1, 0)
     final_ring.Update()
 
@@ -313,7 +330,8 @@ def reducer_data(
     append_polydata.AddInputData(external_face)
     append_polydata.Update()
 
-    return append_polydata.GetOutput()
+    return apply_transform(append_polydata.GetOutput(), rz=-90)
+    # return append_polydata.GetOutput()
 
 
 def flange_data(length, outside_diameter, thickness, n_bolts=8, offset_y=0, offset_z=0):
@@ -328,15 +346,17 @@ def flange_data(length, outside_diameter, thickness, n_bolts=8, offset_y=0, offs
         bolt.SetHeight(length + bolt_radius * 2)
         bolt.SetRadius(bolt_radius)
         bolt.SetCenter(
-            offset_y + (outside_diameter - bolt_radius * 4) * np.sin(angle) / 2,
+            offset_z + (outside_diameter - bolt_radius * 4) * np.sin(angle) / 2,
             length / 2,
-            offset_z + (outside_diameter - bolt_radius * 4) * np.cos(angle) / 2,
+            offset_y + (outside_diameter - bolt_radius * 4) * np.cos(angle) / 2,
         )
         bolt.Update()
         append_polydata.AddInputData(bolt.GetOutput())
 
     append_polydata.Update()
-    return append_polydata.GetOutput()
+
+    return apply_transform(append_polydata.GetOutput(), rz=-90)
+    # return append_polydata.GetOutput()
 
 
 def expansion_joint_data(length, outside_diameter, thickness):
@@ -403,7 +423,9 @@ def expansion_joint_data(length, outside_diameter, thickness):
         append_polydata.AddInputData(final_nut.GetOutput())
 
     append_polydata.Update()
-    return append_polydata.GetOutput()
+
+    return apply_transform(append_polydata.GetOutput(), rz=-90)
+    # return append_polydata.GetOutput()
 
 
 def valve_data(length, outside_diameter, thickness, flange_diameter, flange_length):
@@ -425,7 +447,9 @@ def valve_data(length, outside_diameter, thickness, flange_diameter, flange_leng
     append_polydata.AddInputData(handle)
 
     append_polydata.Update()
-    return append_polydata.GetOutput()
+
+    return apply_transform(append_polydata.GetOutput(), rz=-90)
+    # return append_polydata.GetOutput()
 
 
 def valve_handle(outside_diameter):
@@ -457,4 +481,5 @@ def valve_handle(outside_diameter):
     append_polydata.AddInputData(wheel)
     append_polydata.Update()
 
-    return append_polydata.GetOutput()
+    return apply_transform(append_polydata.GetOutput(), rz=-90)
+    # return append_polydata.GetOutput()

--- a/pulse/utils/cross_section_sources.py
+++ b/pulse/utils/cross_section_sources.py
@@ -37,6 +37,7 @@ def apply_transform(data, dx=0, dy=0, dz=0, rx=0, ry=0, rz=0, sx=1, sy=1, sz=1):
     transform_filter.SetInputData(data)
     transform_filter.SetTransform(transform)
     transform_filter.Update()
+
     return transform_filter.GetOutput()
 
 VALVE_WHEEL = load_symbol(SYMBOLS_DIR / "other/valve_wheel.obj")
@@ -49,6 +50,7 @@ def closed_pipe_data(length, outside_diameter, offset_y=0, offset_z=0, sides=20)
     cilinder.SetHeight(length)
     cilinder.CappingOn()
     cilinder.Update()
+
     return apply_transform(cilinder.GetOutput(), rz=-90)
 
 def pipe_data(length, outside_diameter, thickness, offset_y=0, offset_z=0, sides=20):
@@ -320,7 +322,6 @@ def reducer_data(
     append_polydata.Update()
 
     return apply_transform(append_polydata.GetOutput(), rz=-90)
-    # return append_polydata.GetOutput()
 
 def flange_data(length, outside_diameter, thickness, n_bolts=8, offset_y=0, offset_z=0):
     pipe = closed_pipe_data(length, outside_diameter, offset_y, offset_z)
@@ -344,7 +345,6 @@ def flange_data(length, outside_diameter, thickness, n_bolts=8, offset_y=0, offs
     append_polydata.Update()
 
     return apply_transform(append_polydata.GetOutput(), rz=-90)
-    # return append_polydata.GetOutput()
 
 def expansion_joint_data(length, outside_diameter, thickness):
     append_polydata = vtkAppendPolyData()
@@ -412,7 +412,6 @@ def expansion_joint_data(length, outside_diameter, thickness):
     append_polydata.Update()
 
     return apply_transform(append_polydata.GetOutput(), rz=-90)
-    # return append_polydata.GetOutput()
 
 def valve_data(length, outside_diameter, thickness, flange_diameter, flange_length):
     append_polydata = vtkAppendPolyData()
@@ -435,7 +434,6 @@ def valve_data(length, outside_diameter, thickness, flange_diameter, flange_leng
     append_polydata.Update()
 
     return apply_transform(append_polydata.GetOutput(), rz=-90)
-    # return append_polydata.GetOutput()
 
 def valve_handle(outside_diameter):
     height = 1.5 * outside_diameter
@@ -467,4 +465,3 @@ def valve_handle(outside_diameter):
     append_polydata.Update()
 
     return apply_transform(append_polydata.GetOutput(), rz=-90)
-    # return append_polydata.GetOutput()

--- a/pulse/utils/rotations.py
+++ b/pulse/utils/rotations.py
@@ -1,7 +1,10 @@
 import numpy as np
+from scipy.spatial.transform import Rotation
 from vtkmodules.vtkCommonDataModel import vtkPolyData
 from vtkmodules.vtkCommonTransforms import vtkTransform
 from vtkmodules.vtkFiltersGeneral import vtkTransformFilter
+
+from pulse.utils.common_utils import transformation_matrix_3x3
 
 
 def align_y_rotations(vector):
@@ -34,14 +37,26 @@ def align_y_rotations(vector):
 
 def align_vtk_geometry(geometry: vtkPolyData, start: np.ndarray, vector: np.ndarray, angle: float = 0):
     x, y, z = start
-    rx, ry, rz = align_y_rotations(vector)
+
+    # compute the transformation matrix
+    transformation_matrices = transformation_matrix_3x3( 
+        vector[0],
+        vector[1],
+        vector[2],
+        gamma = angle,
+        )
+
+    # compute the rotation matrix
+    rot_matrix = Rotation.from_matrix(transformation_matrices)
+
+    # compute the rotation angles rz, rx and ry in degrees
+    rz, rx, ry = -rot_matrix.as_euler('zxy', degrees=True)
 
     transform = vtkTransform()
     transform.Translate(x, y, z)
-    transform.RotateZ(np.degrees(rz))
-    transform.RotateX(np.degrees(rx))
-    transform.RotateY(np.degrees(ry))
-    transform.RotateY(np.degrees(angle) - 90)
+    transform.RotateZ(rz)
+    transform.RotateX(rx)
+    transform.RotateY(ry)
     transform.Update()
 
     transform_filter = vtkTransformFilter()


### PR DESCRIPTION
This pull request reviews the VTK actors used to construct the geometry editor structures beyond the elements of model setup and model results renders. The beam elements are now being centralized in their respective centroids. The procedure adopted to compute the rotations, used to align the VTK actos in the geometry editor, was also updated. Please, @andrefpf, I kindly ask that you review the proposed modifications brought with this PR.