### PR TITLE
Automatically close linked issues on PR merge

### DIFF
--- a/.github/workflows/close_issues_on_merge.yml
+++ b/.github/workflows/close_issues_on_merge.yml
@@ -1,0 +1,30 @@
+name: Close linked issues on merge
+
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  issues: write
+
+jobs:
+  close-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Close issues referenced in PR body
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          REPO: ${{ github.repository }}
+        run: |
+          echo "$PR_BODY" \
+            | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#([0-9]+)' \
+            | grep -oE '[0-9]+' \
+            | while read issue; do
+                echo "Closing issue #$issue"
+                gh issue close "$issue" --repo "$REPO" \
+                  --comment "Closed by #${{ github.event.pull_request.number }}."
+              done

--- a/.github/workflows/close_issues_on_merge.yml
+++ b/.github/workflows/close_issues_on_merge.yml
@@ -20,11 +20,18 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
           REPO: ${{ github.repository }}
         run: |
-          echo "$PR_BODY" \
-            | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#([0-9]+)' \
+          issues=$(echo "$PR_BODY" \
+            | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' \
             | grep -oE '[0-9]+' \
-            | while read issue; do
-                echo "Closing issue #$issue"
-                gh issue close "$issue" --repo "$REPO" \
-                  --comment "Closed by #${{ github.event.pull_request.number }}."
-              done
+            | sort -u || true)
+
+          if [ -z "$issues" ]; then
+            echo "No linked issues found in PR body."
+            exit 0
+          fi
+
+          for issue in $issues; do
+            echo "Closing issue #$issue"
+            gh issue close "$issue" --repo "$REPO" \
+              --comment "Closed by #${{ github.event.pull_request.number }}." || true
+          done


### PR DESCRIPTION
Adds a GitHub Action (.github/workflows/close_issues_on_merge.yml) that, when a PR is merged, reads the closing keywords from the PR description (closes #..., fixes #..., resolves #..., and their variations) and closes the referenced issues, adding a comment linking back to the PR.

Details:

- Runs only when the PR is actually merged (not just closed).
- Recognizes close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved (case-insensitive).
- Does not fail when the PR references no issues.
- Avoids duplicates and won't break if an issue is already closed.