### PR TITLE
Fix the error generated while mapping boundary conditions linked by two nodes

### DIFF
--- a/pulse/model/preprocessor.py
+++ b/pulse/model/preprocessor.py
@@ -584,6 +584,10 @@ class Preprocessor:
         else:
             diff = np.linalg.norm(coord_matrix[:,1:] - np.array(coords), axis=1)
             mask = diff < radius
+
+            if not external_indexes[mask].any():
+                return None
+
             try:
                 external_index = int(external_indexes[mask].item())
             except Exception as error_log:

--- a/pulse/project/load_project.py
+++ b/pulse/project/load_project.py
@@ -563,6 +563,8 @@ class LoadProject:
                 continue
         
             coords = np.array(data["coords"], dtype=float)
+
+            # two nodes-related boundary conditions id mapping
             if len(coords) == 6:
 
                 node_id1, node_id2 = args
@@ -576,16 +578,18 @@ class LoadProject:
                     property_to_remove[property] = args
 
                 if new_node_id1 is None:
-                    non_mapped_nodes.append((node_id1, coords))
-                    continue
+                    non_mapped_nodes.append((node_id1, coords_1))
 
                 if new_node_id2 is None:
-                    non_mapped_nodes.append((node_id2, coords))
+                    non_mapped_nodes.append((node_id2, coords_2))
+
+                if (new_node_id1, new_node_id2).count(None):
                     continue
 
                 sorted_indexes = np.sort([new_node_id1, new_node_id2])
                 new_key = (property, sorted_indexes[0], sorted_indexes[1])
 
+            # one node-related boundary conditions id mapping
             elif len(coords) == 3:
 
                 node_id = args


### PR DESCRIPTION
This pull request fixes the bug that occurs when removing structures containing boundary conditions linked by two nodes. It also resolves #505.