### PR TITLE
Add a loading window during the initialization of the fluid composition UI

### DIFF
--- a/pulse/interface/user_input/model/setup/fluid/refprop_interface.py
+++ b/pulse/interface/user_input/model/setup/fluid/refprop_interface.py
@@ -8,7 +8,7 @@ from PySide6.QtWidgets import QFileDialog
 from pulse import app
 from pulse.interface import error_title, warning_title
 from pulse.interface.user_input.project.print_message import PrintMessageInput
-from pulse.utils.common_utils import get_new_path
+# from pulse.utils.common_utils import get_new_path
 from time import perf_counter
 
 IS_ERROR_REGEX = re.compile(r"\[\w+\s+error")
@@ -129,6 +129,11 @@ class RefpropInterface:
             self.refprop_fluids = dict()
             self.fluid_file_to_final_name = dict()
 
+            dt = perf_counter() - t0
+            print(f"Time to read the dll data (a): {dt} s")
+
+            t0 = perf_counter()
+
             for fluid_file in os.listdir(refProp_fluids_path):
                 if ".BNC" in fluid_file:
                     continue
@@ -144,16 +149,20 @@ class RefpropInterface:
                 f.close()
                 short_name = line_0.split("!")[0]
                 full_name = line_2.split("!")[0]
-        
-                letter = " "
-                while letter == " ":
-                    short_name = short_name[:-1]
-                    letter = short_name[-1]
+
+                # remove empty rear spaces
+                short_name = short_name.rstrip()
+                full_name = full_name.rstrip()
+
+                # spacing = " "
+                # while spacing == " ":
+                #     short_name = short_name[:-1]
+                #     spacing = short_name[-1]
                     
-                letter = " "
-                while letter == " ":
-                    full_name = full_name[:-1]
-                    letter = full_name[-1]
+                # spacing = " "
+                # while spacing == " ":
+                #     full_name = full_name[:-1]
+                #     spacing = full_name[-1]
 
                 final_name = short_name if short_name == full_name else f"{short_name} ({full_name})"
 
@@ -161,7 +170,7 @@ class RefpropInterface:
                 self.fluid_file_to_final_name[fluid_file] = final_name
 
             dt = perf_counter() - t0
-            print(f"Time to read the dll data: {dt} s")
+            print(f"Time to read the dll data (b): {dt} s")
 
         except Exception as error_log:
             title = "Error while loading REFPROP"

--- a/pulse/interface/user_input/model/setup/fluid/refprop_interface.py
+++ b/pulse/interface/user_input/model/setup/fluid/refprop_interface.py
@@ -1,6 +1,7 @@
 import os
 import re
 from pathlib import Path
+import logging
 
 import numpy as np
 from PySide6.QtWidgets import QFileDialog
@@ -8,8 +9,6 @@ from PySide6.QtWidgets import QFileDialog
 from pulse import app
 from pulse.interface import error_title, warning_title
 from pulse.interface.user_input.project.print_message import PrintMessageInput
-# from pulse.utils.common_utils import get_new_path
-from time import perf_counter
 
 IS_ERROR_REGEX = re.compile(r"\[\w+\s+error")
 IS_WARNING_REGEX = re.compile(r"\[\w+\s+warning")
@@ -42,7 +41,7 @@ class RefpropInterface:
             "BS" : "adiabatic_bulk_modulus",
             "KKT" : "isothermal_bulk_modulus",
             "Z" : "compressibility_factor",
-            }
+        }
 
     def get_refprop_path(self) -> None | str:
 
@@ -91,15 +90,12 @@ class RefpropInterface:
             return True
 
     def initialize_REFPROP(self):
-        print("initialize_REFPROP")
+
         try:
             
-            t0 = perf_counter()
             from ctREFPROP.ctREFPROP import REFPROPFunctionLibrary
-            dt = perf_counter() - t0
-            print(f"Time to import library: {dt} s")
 
-            t0 = perf_counter()
+            logging.info("Loading REFPROP interface [30%]")
             refProp_path = self.get_refprop_path()
             if refProp_path is None:
                 return True
@@ -111,35 +107,23 @@ class RefpropInterface:
                 PrintMessageInput([error_title, title, message])
                 return True
 
-            dt = perf_counter() - t0
-            print(f"Time to process (A): {dt} s")
-
-            t0 = perf_counter()
+            logging.info("Loading REFPROP interface [40%]")
             self.refprop = REFPROPFunctionLibrary(refProp_path)
             if self.check_refprop_version():
                 return True
-            
-            dt = perf_counter() - t0
-            print(f"Time to initialize REFPROPFunctionLibrary: {dt} s")
-
-            t0 = perf_counter()
+ 
+            logging.info("Loading REFPROP interface [50%]")
             self.refprop.SETPATHdll(refProp_path)
             refProp_fluids_path = Path(refProp_path) / "FLUIDS"
 
             self.refprop_fluids = dict()
             self.fluid_file_to_final_name = dict()
 
-            dt = perf_counter() - t0
-            print(f"Time to read the dll data (a): {dt} s")
-
-            t0 = perf_counter()
-
             for fluid_file in os.listdir(refProp_fluids_path):
                 if ".BNC" in fluid_file:
                     continue
 
                 filepath = Path(refProp_fluids_path) / fluid_file
-                # filepath = get_new_path(refProp_fluids_path, fluid_file)
 
                 f = open(filepath, 'r')
                 line_0 = f.readline()
@@ -154,23 +138,10 @@ class RefpropInterface:
                 short_name = short_name.rstrip()
                 full_name = full_name.rstrip()
 
-                # spacing = " "
-                # while spacing == " ":
-                #     short_name = short_name[:-1]
-                #     spacing = short_name[-1]
-                    
-                # spacing = " "
-                # while spacing == " ":
-                #     full_name = full_name[:-1]
-                #     spacing = full_name[-1]
-
                 final_name = short_name if short_name == full_name else f"{short_name} ({full_name})"
 
                 self.refprop_fluids[final_name] = [fluid_file, short_name, full_name]
                 self.fluid_file_to_final_name[fluid_file] = final_name
-
-            dt = perf_counter() - t0
-            print(f"Time to read the dll data (b): {dt} s")
 
         except Exception as error_log:
             title = "Error while loading REFPROP"
@@ -192,16 +163,16 @@ class RefpropInterface:
         
         units = self.refprop.GETENUMdll(0, "MASS BASE SI").iEnum
         read = self.refprop.REFPROPdll( 
-                                        key_mixture, 
-                                        state_properties, 
-                                        property_key, 
-                                        units, 
-                                        0, 
-                                        0, 
-                                        temperature_K, 
-                                        pressure_Pa, 
-                                        molar_fractions
-                                        )
+            key_mixture,
+            state_properties,
+            property_key,
+            units,
+            0,
+            0,
+            temperature_K,
+            pressure_Pa,
+            molar_fractions,
+        )
 
         if IS_ERROR_REGEX.match(read.herr):
             errors = read.herr
@@ -255,7 +226,7 @@ class RefpropInterface:
                     property_key = prop_key,
                     temperature_K = temperature_K,
                     pressure_Pa = pressure_Pa,
-                    )
+                )
 
                 if errors:
                     print(errors)

--- a/pulse/interface/user_input/model/setup/fluid/refprop_interface.py
+++ b/pulse/interface/user_input/model/setup/fluid/refprop_interface.py
@@ -9,6 +9,7 @@ from pulse import app
 from pulse.interface import error_title, warning_title
 from pulse.interface.user_input.project.print_message import PrintMessageInput
 from pulse.utils.common_utils import get_new_path
+from time import perf_counter
 
 IS_ERROR_REGEX = re.compile(r"\[\w+\s+error")
 IS_WARNING_REGEX = re.compile(r"\[\w+\s+warning")
@@ -90,10 +91,15 @@ class RefpropInterface:
             return True
 
     def initialize_REFPROP(self):
+        print("initialize_REFPROP")
         try:
             
+            t0 = perf_counter()
             from ctREFPROP.ctREFPROP import REFPROPFunctionLibrary
+            dt = perf_counter() - t0
+            print(f"Time to import library: {dt} s")
 
+            t0 = perf_counter()
             refProp_path = self.get_refprop_path()
             if refProp_path is None:
                 return True
@@ -105,43 +111,57 @@ class RefpropInterface:
                 PrintMessageInput([error_title, title, message])
                 return True
 
+            dt = perf_counter() - t0
+            print(f"Time to process (A): {dt} s")
+
+            t0 = perf_counter()
             self.refprop = REFPROPFunctionLibrary(refProp_path)
             if self.check_refprop_version():
                 return True
+            
+            dt = perf_counter() - t0
+            print(f"Time to initialize REFPROPFunctionLibrary: {dt} s")
 
+            t0 = perf_counter()
             self.refprop.SETPATHdll(refProp_path)
-            refProp_fluids_path = get_new_path(refProp_path, "FLUIDS")
-            list_files = os.listdir(refProp_fluids_path)
+            refProp_fluids_path = Path(refProp_path) / "FLUIDS"
 
             self.refprop_fluids = dict()
             self.fluid_file_to_final_name = dict()
 
-            for fluid_file in list_files:
-                if ".BNC" not in fluid_file:
-                    filepath = get_new_path(refProp_fluids_path, fluid_file)
+            for fluid_file in os.listdir(refProp_fluids_path):
+                if ".BNC" in fluid_file:
+                    continue
+
+                filepath = Path(refProp_fluids_path) / fluid_file
+                # filepath = get_new_path(refProp_fluids_path, fluid_file)
+
+                f = open(filepath, 'r')
+                line_0 = f.readline()
+                line_1 = f.readline()
+                line_2 = f.readline()
+
+                f.close()
+                short_name = line_0.split("!")[0]
+                full_name = line_2.split("!")[0]
+        
+                letter = " "
+                while letter == " ":
+                    short_name = short_name[:-1]
+                    letter = short_name[-1]
                     
-                    f = open(filepath, 'r')
-                    line_0 = f.readline()
-                    line_1 = f.readline()
-                    line_2 = f.readline()
+                letter = " "
+                while letter == " ":
+                    full_name = full_name[:-1]
+                    letter = full_name[-1]
 
-                    f.close()
-                    short_name = line_0.split("!")[0]
-                    full_name = line_2.split("!")[0]
-            
-                    letter = " "
-                    while letter == " ":
-                        short_name = short_name[:-1]
-                        letter = short_name[-1]
-                        
-                    letter = " "
-                    while letter == " ":
-                        full_name = full_name[:-1]
-                        letter = full_name[-1]
+                final_name = short_name if short_name == full_name else f"{short_name} ({full_name})"
 
-                    final_name = short_name if short_name == full_name else f"{short_name} ({full_name})"
-                    self.refprop_fluids[final_name] = [fluid_file, short_name, full_name]
-                    self.fluid_file_to_final_name[fluid_file] = final_name
+                self.refprop_fluids[final_name] = [fluid_file, short_name, full_name]
+                self.fluid_file_to_final_name[fluid_file] = final_name
+
+            dt = perf_counter() - t0
+            print(f"Time to read the dll data: {dt} s")
 
         except Exception as error_log:
             title = "Error while loading REFPROP"

--- a/pulse/interface/user_input/model/setup/fluid/set_fluid_composition_input.py
+++ b/pulse/interface/user_input/model/setup/fluid/set_fluid_composition_input.py
@@ -1,4 +1,6 @@
 
+import logging
+
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QAbstractItemView,
@@ -33,9 +35,9 @@ from pulse.interface.user_input.numeric_checks.unit_utilities import (
 from pulse.interface.user_input.project.get_user_confirmation_input import (
     GetUserConfirmationInput,
 )
+from pulse.interface.user_input.project.loading_window import LoadingWindow
 from pulse.interface.user_input.project.print_message import PrintMessageInput
 from pulse.model.properties.fluid import Fluid
-from time import perf_counter
 
 
 class SetFluidCompositionInput(SetFluidCompositionInput_UI):
@@ -47,26 +49,17 @@ class SetFluidCompositionInput(SetFluidCompositionInput_UI):
 
         app().main_window.set_input_widget(self)
 
-        t0 = perf_counter()
         self._config_window()
         self._initialize()
         self._config_widgets()
         self._create_connections()
-        dt = perf_counter() - t0
-        print(f"Tempo gasto em A: {dt} s")
 
         if self.state_properties: 
             self.check_state_properties(self.state_properties)
 
-        t0 = perf_counter()
-        print()
-
         self.update_remainig_composition()
-        if self.initialize_refprop_interface():
+        if LoadingWindow(self.initialize_refprop_interface).run():
             return
-        
-        dt = perf_counter() - t0
-        print(f"Tempo gasto em B: {dt} s")
 
         self.update_selected_fluid(fluid_to_edit = self.fluid_to_edit)
 
@@ -168,25 +161,20 @@ class SetFluidCompositionInput(SetFluidCompositionInput_UI):
         self.lineEdit_temperature_right.setValidator(StrictDoubleValidator(t_min, t_max, 6))
 
     def initialize_refprop_interface(self):
-        t0 = perf_counter()
+        logging.info("Loading REFPROP interface [10%]")
         self.refprop_interface = RefpropInterface()
-        dt = perf_counter() - t0
-        print(f"Time to process A: {dt} s")
 
-        t0 = perf_counter()
         if self.refprop_interface.initialize_REFPROP():
             return True
-        dt = perf_counter() - t0
-        print(f"Time to process B: {dt} s")
+        
+        logging.info("Loading REFPROP interface [80%]")
 
-        t0 = perf_counter()
         self.refprop = self.refprop_interface.refprop
         self.load_default_gases_info(self.refprop_interface.refprop_fluids)
 
+        logging.info("Loading REFPROP interface [95%]")
         version = self.refprop_interface.get_REFPROP_version()
         self.setWindowTitle(f"OpenPulse (REFPROP v{version})")
-        dt = perf_counter() - t0
-        print(f"Time to process C: {dt} s")
 
     def _create_connections(self):
         #

--- a/pulse/interface/user_input/model/setup/fluid/set_fluid_composition_input.py
+++ b/pulse/interface/user_input/model/setup/fluid/set_fluid_composition_input.py
@@ -35,6 +35,7 @@ from pulse.interface.user_input.project.get_user_confirmation_input import (
 )
 from pulse.interface.user_input.project.print_message import PrintMessageInput
 from pulse.model.properties.fluid import Fluid
+from time import perf_counter
 
 
 class SetFluidCompositionInput(SetFluidCompositionInput_UI):
@@ -46,17 +47,26 @@ class SetFluidCompositionInput(SetFluidCompositionInput_UI):
 
         app().main_window.set_input_widget(self)
 
+        t0 = perf_counter()
         self._config_window()
         self._initialize()
         self._config_widgets()
         self._create_connections()
+        dt = perf_counter() - t0
+        print(f"Tempo gasto em A: {dt} s")
 
         if self.state_properties: 
             self.check_state_properties(self.state_properties)
 
+        t0 = perf_counter()
+        print()
+
         self.update_remainig_composition()
         if self.initialize_refprop_interface():
             return
+        
+        dt = perf_counter() - t0
+        print(f"Tempo gasto em B: {dt} s")
 
         self.update_selected_fluid(fluid_to_edit = self.fluid_to_edit)
 
@@ -158,15 +168,25 @@ class SetFluidCompositionInput(SetFluidCompositionInput_UI):
         self.lineEdit_temperature_right.setValidator(StrictDoubleValidator(t_min, t_max, 6))
 
     def initialize_refprop_interface(self):
+        t0 = perf_counter()
         self.refprop_interface = RefpropInterface()
+        dt = perf_counter() - t0
+        print(f"Time to process A: {dt} s")
+
+        t0 = perf_counter()
         if self.refprop_interface.initialize_REFPROP():
             return True
+        dt = perf_counter() - t0
+        print(f"Time to process B: {dt} s")
 
+        t0 = perf_counter()
         self.refprop = self.refprop_interface.refprop
         self.load_default_gases_info(self.refprop_interface.refprop_fluids)
 
         version = self.refprop_interface.get_REFPROP_version()
         self.setWindowTitle(f"OpenPulse (REFPROP v{version})")
+        dt = perf_counter() - t0
+        print(f"Time to process C: {dt} s")
 
     def _create_connections(self):
         #


### PR DESCRIPTION
This pull request adds a loading window during the initialization of the fluid composition user interface. I took the opportunity to simplify the methods for reading the REFPROP fluids library. It also resolves the issue #492.