### PR TITLE
Reset section plane state when a new project is created or loaded

### DIFF
--- a/pulse/interface/main_window.py
+++ b/pulse/interface/main_window.py
@@ -943,6 +943,7 @@ class MainWindow(MainWindow_UI):
         self.set_toolbars_visible(True)
         self.animation_toolbar.set_visible(False)
         self.update_results_workspace_button_accessibility()
+        self.section_plane.reset_state()
 
         return obj.complete
 
@@ -989,6 +990,7 @@ class MainWindow(MainWindow_UI):
             self.action_model_setup_workspace_callback()
             self.set_toolbars_visible(True)
             self.animation_toolbar.set_visible(False)
+            self.section_plane.reset_state()
             self.update_results_workspace_button_accessibility()
             self.update_plots()
 

--- a/pulse/interface/user_input/render/section_plane_widget.py
+++ b/pulse/interface/user_input/render/section_plane_widget.py
@@ -93,6 +93,19 @@ class SectionPlaneWidget(SectionPlaneInputs_UI):
         self.cutting = True
         self.value_changed_2.emit()
 
+    def reset_state(self):
+        self.editing = False
+        self.cutting = False
+        self.invert_value = False
+        self.keep_section_plane = False
+
+        action = app().main_window.action_section_plane
+        action.blockSignals(True)
+        action.setChecked(False)
+        action.blockSignals(False)
+
+        self.reset_button_callback()
+
     def reset_button_callback(self):
         self.relative_plane_position_x_slider.setValue(50),
         self.relative_plane_position_y_slider.setValue(50),


### PR DESCRIPTION
## What does this PR do?
This PR adds the `reset_state` method in the `SectionPlaneWidget`. Now, when a new project is created or an existing project is opened, the `reset_state `method is called, ensuring that the section plane state is reset.

Closes #474