### PR TITLE
Update StrictDoubleValidator to allow empty strings

### DIFF
--- a/pulse/interface/user_input/numeric_checks/double_validator.py
+++ b/pulse/interface/user_input/numeric_checks/double_validator.py
@@ -25,7 +25,7 @@ class StrictDoubleValidator(QDoubleValidator):
         string = string.replace(",", ".")
 
         if not string:
-            return QDoubleValidator.State.Intermediate, string, pos
+            return QDoubleValidator.State.Acceptable, string, pos
 
         if string.count(".") > 1:
             return QDoubleValidator.State.Invalid, string, pos


### PR DESCRIPTION
Allow empty strings in the StrictDoubleValidator to avoid the previous annoyance.