### PR TITLE
Disable section plane

### DIFF
--- a/pulse/interface/main_window.py
+++ b/pulse/interface/main_window.py
@@ -693,7 +693,7 @@ class MainWindow(MainWindow_UI):
             self.section_plane.show()
         else:
             self.section_plane.keep_section_plane = False
-            self.section_plane.close()
+            self.section_plane.disable_section_plane()
 
     def action_zoom_callback(self):
         self.geometry_widget.renderer.ResetCamera()

--- a/pulse/interface/user_input/render/section_plane_widget.py
+++ b/pulse/interface/user_input/render/section_plane_widget.py
@@ -62,8 +62,17 @@ class SectionPlaneWidget(SectionPlaneInputs_UI):
             self.cutting = False
         else:
             self.cutting = True
+
         self.value_changed_2.emit()
-        # self.closed.emit()
+    
+    def disable_section_plane(self):
+        self.cutting = False
+
+        if self.isVisible():
+            self.close()
+            return
+
+        self.value_changed_2.emit()
 
     def get_position(self):
         Px = self.relative_plane_position_x_slider.value()

--- a/pulse/interface/user_input/render/section_plane_widget.py
+++ b/pulse/interface/user_input/render/section_plane_widget.py
@@ -5,12 +5,7 @@ from pulse.interface.ui_generated.render.section_plane_inputs_ui import SectionP
 
 
 class SectionPlaneWidget(SectionPlaneInputs_UI):
-    value_changed_2 = Signal()
-
-    value_changed = Signal(float, float, float, float, float, float)
-    slider_released = Signal(float, float, float, float, float, float)
-    slider_pressed = Signal(float, float, float, float, float, float)
-    closed = Signal()
+    value_changed = Signal()
 
     def __init__(self):
         super().__init__()
@@ -52,7 +47,7 @@ class SectionPlaneWidget(SectionPlaneInputs_UI):
         super().show()
         self.cutting = True
         self.keep_section_plane = False
-        self.value_changed_2.emit()
+        self.value_changed.emit()
 
     def closeEvent(self, event):
         if not self.keep_section_plane:
@@ -63,7 +58,7 @@ class SectionPlaneWidget(SectionPlaneInputs_UI):
         else:
             self.cutting = True
 
-        self.value_changed_2.emit()
+        self.value_changed.emit()
     
     def disable_section_plane(self):
         self.cutting = False
@@ -72,7 +67,7 @@ class SectionPlaneWidget(SectionPlaneInputs_UI):
             self.close()
             return
 
-        self.value_changed_2.emit()
+        self.value_changed.emit()
 
     def get_position(self):
         Px = self.relative_plane_position_x_slider.value()
@@ -90,17 +85,17 @@ class SectionPlaneWidget(SectionPlaneInputs_UI):
         return self.invert_value
 
     def value_change_callback(self):
-        self.value_changed_2.emit()
+        self.value_changed.emit()
 
     def slider_pressed_callback(self):
         self.editing = True
         self.cutting = True
-        self.value_changed_2.emit()
+        self.value_changed.emit()
 
     def slider_release_callback(self):
         self.editing = False
         self.cutting = True
-        self.value_changed_2.emit()
+        self.value_changed.emit()
 
     def reset_button_callback(self):
         self.relative_plane_position_x_slider.setValue(50),
@@ -111,11 +106,11 @@ class SectionPlaneWidget(SectionPlaneInputs_UI):
         self.plane_rotation_z_slider.setValue(0),
 
         self.invert_value = False
-        self.value_changed_2.emit()
+        self.value_changed.emit()
 
     def invert_button_callback(self):
         self.invert_value = not self.invert_value
-        self.value_changed_2.emit()
+        self.value_changed.emit()
 
     def apply_callback(self):
         self.keep_section_plane = True

--- a/pulse/interface/viewer_3d/render_widgets/mesh_render_widget.py
+++ b/pulse/interface/viewer_3d/render_widgets/mesh_render_widget.py
@@ -54,7 +54,7 @@ class MeshRenderWidget(CommonRenderWidget):
         app().main_window.theme_changed.connect(self._apply_logo_theme)
         app().main_window.visualization_changed.connect(self.visualization_changed_callback)
         app().main_window.selection_changed.connect(self.update_selection)
-        app().main_window.section_plane.value_changed_2.connect(self.update_section_plane)
+        app().main_window.section_plane.value_changed.connect(self.update_section_plane)
 
     def update_plot(self, reset_camera=False):
         self.remove_all_actors()

--- a/pulse/interface/viewer_3d/render_widgets/results_render_widget.py
+++ b/pulse/interface/viewer_3d/render_widgets/results_render_widget.py
@@ -99,7 +99,7 @@ class ResultsRenderWidget(AnimatedRenderWidget):
         app().main_window.theme_changed.connect(self._apply_logo_theme)
         app().main_window.visualization_changed.connect(self.visualization_changed_callback)
         app().main_window.selection_changed.connect(self.update_selection)
-        app().main_window.section_plane.value_changed_2.connect(self.update_section_plane)
+        app().main_window.section_plane.value_changed.connect(self.update_section_plane)
 
     def update_plot(self, reset_camera=False):
 


### PR DESCRIPTION
## What does this PR do?
This PR disables the section plane cut when the QAction is clicked to disable the section plane.

### Problem
After you applied a cut, the section plane window was closed. Turning off the toolbar button then called `section_plane.close()` on a window that **was already closed** and `cutting` stayed `True`, so the cut stayed on the model.

### Fix
Added `disable_section_plane()` to turn off the cut directly instead of using `close()`. The toolbar button now calls it, and it only closes the window when the window is open (so it does not calls `value_changed_2.emit()` twice).

Closes #482 


