### PR TITLE
fix clipped border around preview render widgets

### DIFF
--- a/pulse/interface/user_input/model/editor/pulsation_damper_editor_inputs.py
+++ b/pulse/interface/user_input/model/editor/pulsation_damper_editor_inputs.py
@@ -308,10 +308,18 @@ class PulsationDamperEditorInputs(PulsationDamperEditorInputs_UI):
         # Replace placeholder widget with the actual render widget
         self.preview_widget = DamperPreviewRenderWidget()
         self.preview_widget.set_isometric_view()
+
+        self.preview_widget.setSizePolicy(self.preview_widget_placeholder.sizePolicy())
+        self.preview_widget.setMinimumSize(self.preview_widget_placeholder.minimumSize())
+
         self.preview_widget_placeholder.parent().layout().replaceWidget(
             self.preview_widget_placeholder,
             self.preview_widget,
         )
+
+        self.preview_widget_placeholder.setParent(None)
+        self.preview_widget_placeholder.deleteLater()
+        
         #
         self.lineEdit_damper_label.setFocus()
         self.lineEdit_selected_damper_label.setDisabled(True)

--- a/pulse/interface/user_input/model/editor/pulsation_suppression_device_inputs.py
+++ b/pulse/interface/user_input/model/editor/pulsation_suppression_device_inputs.py
@@ -151,10 +151,18 @@ class PulsationSuppressionDeviceInputs(PulsationSuppressionDeviceInput_UI):
         # Replace placeholder widget with the actual render widget
         self.preview_widget = PSDPreviewRenderWidget()
         self.preview_widget.set_isometric_view()
+
+        self.preview_widget.setSizePolicy(self.preview_widget_placeholder.sizePolicy())
+        self.preview_widget.setMinimumSize(self.preview_widget_placeholder.minimumSize())
+
         self.preview_widget_placeholder.parent().layout().replaceWidget(
             self.preview_widget_placeholder,
             self.preview_widget,
         )
+
+        self.preview_widget_placeholder.setParent(None)
+        self.preview_widget_placeholder.deleteLater()
+
         #
         self.lineEdit_device_label.setFocus()
         self.lineEdit_selection.setDisabled(True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dev = [
 [tool.uv]
 
 [tool.uv.sources]
-molde = { git = "https://github.com/andrefpf/molde.git", branch = "main" }
+molde = { git = "https://github.com/MOPT-UFSC/molde.git", branch = "main" }
 
 [build-system]
 requires = ["hatchling"]

--- a/uv.lock
+++ b/uv.lock
@@ -115,7 +115,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -186,7 +186,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -291,7 +291,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -693,7 +693,7 @@ wheels = [
 [[package]]
 name = "molde"
 version = "0.1.18"
-source = { git = "https://github.com/andrefpf/molde.git?branch=main#5205aec44584092bc86e4708bfba2a84aa2f61b0" }
+source = { git = "https://github.com/MOPT-UFSC/molde.git?branch=main#b4178213b37d30c92b2f5ca5e8414641dfd950e0" }
 dependencies = [
     { name = "moviepy" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1023,10 +1023,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "flexcache", marker = "python_full_version < '3.11'" },
-    { name = "flexparser", marker = "python_full_version < '3.11'" },
-    { name = "platformdirs", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "flexcache" },
+    { name = "flexparser" },
+    { name = "platformdirs" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/bb/52b15ddf7b7706ed591134a895dbf6e41c8348171fb635e655e0a4bbb0ea/pint-0.24.4.tar.gz", hash = "sha256:35275439b574837a6cd3020a5a4a73645eb125ce4152a73a2f126bf164b91b80", size = 342225, upload-time = "2024-11-07T16:29:46.061Z" }
 wheels = [
@@ -1042,10 +1042,10 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "flexcache", marker = "python_full_version >= '3.11'" },
-    { name = "flexparser", marker = "python_full_version >= '3.11'" },
-    { name = "platformdirs", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+    { name = "flexcache" },
+    { name = "flexparser" },
+    { name = "platformdirs" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/52/9d/b1379cdbd33a49d17d627bc24e2b63cca06a1c5343b38072d2889499e82e/pint-0.25.3.tar.gz", hash = "sha256:f8f5df6cf65314d74da1ade1bf96f8e3e4d0c41b51577ac53c49e7d44ca5acee", size = 255106, upload-time = "2026-03-19T21:57:08.72Z" }
 wheels = [
@@ -1156,7 +1156,7 @@ requires-dist = [
     { name = "gmsh", specifier = ">=4.13.1,<5" },
     { name = "h5py", specifier = ">=3.12.1,<4" },
     { name = "matplotlib", specifier = ">=3.7.2,<4" },
-    { name = "molde", marker = "python_full_version >= '3.10'", git = "https://github.com/andrefpf/molde.git?branch=main" },
+    { name = "molde", marker = "python_full_version >= '3.10'", git = "https://github.com/MOPT-UFSC/molde.git?branch=main" },
     { name = "numpy", specifier = ">=2.1.2,<3" },
     { name = "openpyxl", specifier = ">=3.1.2,<4" },
     { name = "ordered-set", specifier = ">=4.1.0,<5" },
@@ -1305,7 +1305,7 @@ name = "pyqtdarktheme"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "darkdetect", marker = "python_full_version < '3.12'" },
+    { name = "darkdetect" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5c/f1/786feaad7a333072b34a913dbe38aef94b5ae43ad188934f5d70007aea79/pyqtdarktheme-2.1.0.tar.gz", hash = "sha256:5f8274ddfa3a5481ed9743cdb0f9debfeb7ff695b3a0d202a8104361d17dadb8", size = 42186, upload-time = "2022-12-25T08:33:11.662Z" }
 wheels = [
@@ -1540,7 +1540,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -1600,7 +1600,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [


### PR DESCRIPTION
Fix clipped border on the PSD and damper preview widgets. When the render widget replaces preview_widget_placeholder, it doesn't inherit the placeholder's sizePolicy and minimumSize, so the layout ended up calculating a slightly different space for the render widget, and that size mismatch was enough to cover part of the frame's border. The fix copies sizePolicy and minimumSize from the placeholder to the render widget, so the layout allocates the same space as before, and detaches the leftover placeholder with setParent(None) and deleteLater() to avoid an orphaned widget.

<img width="972" height="891" alt="Captura de tela 2026-07-20 165618" src="https://github.com/user-attachments/assets/e63705e4-69a0-46eb-84d1-0ed06a4c4398" />
<img width="655" height="940" alt="image" src="https://github.com/user-attachments/assets/dae6dde3-9a04-4ba1-b80c-2b9855c8098a" />
